### PR TITLE
feat: rework pricing page with GBP day rate as source of truth

### DIFF
--- a/.cspell/my-words.txt
+++ b/.cspell/my-words.txt
@@ -61,3 +61,4 @@ Woah
 Woot
 YOLO
 zipline
+HMRC

--- a/copy/lets-work-together.md
+++ b/copy/lets-work-together.md
@@ -1,8 +1,8 @@
 <script>
  import {
-    DateDistance as DD, 
-    DateUpdated, 
-    Small, 
+    DateDistance as DD,
+    DateUpdated,
+    Small,
   } from '$lib/components'
  import {
     BlogPost,
@@ -15,37 +15,39 @@
 # Let's work together!
 
 <Small>
-  Last updated: <DateUpdated date='2024-09-22' small='true' />
+  Last updated: <DateUpdated date='2026-03-29' small='true' />
 </Small>
 
 In today's rapidly evolving tech landscape, having a seasoned expert
 on your team can be the difference between success and stagnation.
-With nearly two decades of diverse tech experience, I bring a unique
-blend of technical prowess, leadership skills, and community influence
-to the table.
+With over two decades of diverse tech experience, I bring a unique
+blend of technical expertise, AI engineering leadership, and community
+influence to the table.
 
-## What can an expert Svelte and SvelteKit Developer Advocate do for you?
+## What can an AI & Svelte engineering leader do for you?
 
 With <DD date='2004-06-15' /> of experience in the tech industry,
 including <DD date='2016-06-15' /> of hands-on web and fullstack
-development, I offer more than just coding skills. My proficiency lies
-in empowering teams, driving adoption, and elevating products through
-education, advocacy, and strategic guidance.
+development, I offer more than just coding skills. I build AI-powered
+products, lead engineering teams, and ship fast. My recent work
+includes building an AI customer service agent runtime that reduced
+average handle time by 40%, and developing multi-agent orchestration
+systems with Claude and MCP tooling.
 
-With my diverse background I have honed my skills in stakeholder
-management and realistic project management, which I've successfully
-applied throughout my career. This unique combination allows me to
-bridge the gap between technical implementation and business needs
-effectively.
+I built [Svortie](https://svortie.com) in two weeks between contracts,
+a full agent orchestration platform where you define agents, deploy
+them into sandboxed environments, and monitor execution in real time.
 
-As a Svelte ambassador and co-founder of the Svelte Society London
-events for nearly 3 years, I serve as a bridge between your team and
-the broader Svelte community. This proactive approach can
-significantly boost your product's adoption, visibility, and success.
+As a recognised Svelte ambassador and co-founder of the Svelte Society
+London events (running since November 2021), I bridge the gap between
+your team and the broader Svelte community. This proactive approach
+can significantly boost your product's adoption, visibility, and
+success.
 
-Whether it's delivering top-tier workshops, leading projects, or
-advocating for your product, my diverse skill set can drive tangible
-results for your team and business.
+Whether it's building AI-powered features, delivering top-tier
+workshops, leading projects, or advocating for your product, my
+diverse skill set can drive tangible results for your team and
+business.
 
 ## Workshops & speaking engagements
 
@@ -54,39 +56,38 @@ _**Empowering developers through education**_
 With <DD date='2021-04-21' /> of experience delivering engaging talks
 at events like JSNation, CityJS, Connect.Tech Atlanta, and Jamstack
 Conf, I've honed my skills in translating complex technical concepts
-into actionable learning experiences. My workshops aim to empower
-developers, providing them with the tools and knowledge to navigate
-and utilize Svelte and SvelteKit effectively.
+into actionable learning experiences. My workshops cover Svelte,
+SvelteKit, AI integration, and modern developer tooling.
 
 From beginner-friendly introductions to advanced deep dives, I offer
 workshops that cater to all experience levels. Participants walk away
-with a comprehensive understanding of these powerful tools and the
-ability to implement them effectively in their own projects.
+with a comprehensive understanding of these tools and the ability to
+implement them effectively in their own projects.
 
 ## Consulting & project delivery
 
 _**Bringing expert knowledge and leadership to your team**_
 
-Beyond standalone workshops, I offer long-term consulting services and
-project leadership. As the current Application Team Lead at XtendOps,
-overseeing a large SvelteKit monorepo codebase, I bring valuable
-experience in leading multi-national remote teams and ensuring best
-practices throughout the development lifecycle. For specialized Svelte
-consulting services, visit
-[Svelte Consulting](https://svelteconsulting.dev) or
-[OES Technology](https://oestechnology.co.uk).
+I offer long-term consulting services and project leadership through
+[OES Technology](https://oestechnology.co.uk). Having recently led a
+team of 12 developers across two product teams, overseeing a large
+SvelteKit monorepo codebase, I bring hands-on experience in leading
+multi-national remote teams and ensuring best practices throughout the
+development lifecycle.
 
 My approach is collaborative and adaptive, focusing on creating a
 positive and productive working environment. I believe in the
 importance of communication and transparency in ensuring a project's
 success, and work with team members to foster these values.
 
-Whether your team needs to expand its knowledge of Svelte and
-SvelteKit, or require expert guidance on a major project, my wealth of
-experience can be a valuable asset.
+Whether your team needs to expand its knowledge of Svelte, SvelteKit,
+or AI integration, or requires expert guidance on a major project, my
+wealth of experience can be a valuable asset.
 
 Common scenarios where I deliver successful projects:
 
+- You need an AI engineering leader to build agent-powered features
+  into your product.
 - You need a developer advocate to increase the visibility and
   adoption of your product.
 - You require assistance with workshops, tutorials, demos, educational
@@ -104,15 +105,14 @@ _**Transparency and flexibility**_
 
 I believe in straightforward, transparent pricing. To simplify this
 process, I've added pricing widgets that cover the services I offer,
-all calculated on a single rate.
+all calculated from a single day rate. The currency is automatically
+set based on your location, but you can change it using the dropdown.
 
-_**Currency preference and client location**_
+_**Client location**_
 
 While I'm based in the UK (Swanley, Kent), I've had the privilege to
-work with diverse teams across different time zones. I prefer payments
-in EUR or USD, aligning well with the international tech market.
-However, I'm adaptable and can work with your company's local currency
-if needed.
+work with diverse teams across different time zones. I work with
+clients internationally and can invoice in GBP, USD, EUR, or CAD.
 
 My preference leans towards forming long-lasting relationships with
 international companies, valuing the dynamics of global cooperation
@@ -120,11 +120,10 @@ and the opportunities they present.
 
 ## Rates
 
-The widget below factors in holidays (with 8 days public holidays as
-default). If you're willing to provide Paid Time Off (PTO) or it's a
-short contract, you can adjust using the slider. This gives you an
-idea of the budget and helps align with your existing employment
-practices.
+The rate calculator shows my day rate with options to adjust for PTO.
+If you're willing to provide Paid Time Off or it's a short contract,
+you can adjust using the slider. UK-based clients can also see the
+IR35 inside/outside comparison and full-time salary equivalent.
 
 <Rate />
 
@@ -132,10 +131,10 @@ Now, let's go into specifics:
 
 ## Workshops
 
-I offer several types of workshops to level-up your team's SvelteKit
-skills. From basics through API integration and styling with
+I offer several types of workshops to level-up your team's skills.
+From SvelteKit basics through AI integration and styling with
 contemporary tools like Tailwind and daisyUI, these workshops offer
-comprehensive insights into working with Svelte and SvelteKit.
+comprehensive insights into building modern web applications.
 
 <Workshop />
 
@@ -152,12 +151,12 @@ content for your team or community.
 ## Blog Posts
 
 My blog posts serve as go-to resources for both beginner and seasoned
-developers in the Svelte and SvelteKit space. Covering topics from
-basic concepts to advanced techniques, each post is designed to offer
-actionable insights and solutions. With a proven track record of
-content creation and examples of such content on
-[scottspence.com](https://scottspence.com) (with over 30k monthly
-visitors), I deliver valuable written content for your audience.
+developers. Covering topics from Svelte and SvelteKit to AI tooling
+and developer workflows, each post is designed to offer actionable
+insights and solutions. With a proven track record of content creation
+across 244+ posts on [scottspence.com](https://scottspence.com) (with
+22k+ monthly readers and 1.4M+ total page views), I deliver valuable
+written content for your audience.
 
 <BlogPost />
 
@@ -169,10 +168,10 @@ don't hesitate to [reach out]. I'm here to help.
 ## Why hire me?
 
 With <DD date='2004-06-15' /> of experience in the tech industry,
-including <DD date='2016-06-15' /> of hands-on JavaScript, HTML, and
-CSS experience, I bring a robust and diverse skill set to the table.
-My career spans multiple phases, each contributing unique value to my
-current expertise.
+including <DD date='2016-06-15' /> of hands-on JavaScript, TypeScript,
+HTML, and CSS experience, I bring a robust and diverse skill set to
+the table. My career spans multiple phases, each contributing unique
+value to my current expertise.
 
 ## My background
 
@@ -182,7 +181,10 @@ delivering solutions in high-pressure environments.
 
 For <DD date='2016-06-15' /> now, I've been fully immersed in web and
 fullstack development, working on projects for start-ups, medium to
-large businesses, and international brands.
+large businesses, and international brands. More recently, I've been
+focused on AI engineering — building agent runtimes, multi-agent
+orchestration systems, and developer tooling with Claude, MCP, and
+TypeScript.
 
 This diverse background has allowed me to develop a unique blend of
 technical and soft skills, enabling me to navigate complex project
@@ -196,16 +198,17 @@ technical implementation and business objectives.
 
 ## My skills
 
-I develop solutions using modern tooling and processes, leveraging
-JavaScript, HTML, CSS, and frameworks like Svelte and React. My
-expertise extends to:
+I build AI-powered products and modern web applications using
+TypeScript, SvelteKit, and the Claude ecosystem. My expertise extends
+to:
 
+- AI engineering (Claude API, Agent SDK, MCP tooling)
 - Team leadership and project management
 - Stakeholder management and communication
+- SvelteKit, TypeScript, and fullstack development
 - Developer advocacy and community building
 - Content creation (blog posts, videos, workshops)
-- CI/CD optimization
-- Agile methodologies
+- Infrastructure (AWS, Terraform, CI/CD)
 
 I'm a good communicator, reliable, autonomous, pragmatic, and adept at
 managing both myself and wider teams. My extensive experience has

--- a/migrations/012_pricing_config.sql
+++ b/migrations/012_pricing_config.sql
@@ -1,0 +1,68 @@
+-- Create pricing_config table with GBP day rate as single source of truth
+-- Replaces pricing_numbers (EUR annual rate) with a simpler model:
+-- one day rate in GBP, everything else derived
+
+CREATE TABLE IF NOT EXISTS
+  pricing_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    day_rate_gbp REAL NOT NULL DEFAULT 575,
+    ir35_uplift_pct REAL NOT NULL DEFAULT 25,
+    working_days_in_year INTEGER NOT NULL DEFAULT 252,
+    public_holidays INTEGER NOT NULL DEFAULT 8,
+    default_pto_days INTEGER NOT NULL DEFAULT 30,
+    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  pricing_config (
+    day_rate_gbp,
+    ir35_uplift_pct,
+    working_days_in_year,
+    public_holidays,
+    default_pto_days
+  )
+SELECT
+  575, 25, 252, 8, 30
+WHERE
+  NOT EXISTS (SELECT 1 FROM pricing_config);
+
+-- UK tax bands and rates - stored in DB so they can be updated
+-- without a code deploy when HMRC changes rates.
+-- NOTE: Review annually around March/April budget.
+-- Current rates: 2025/26 tax year (frozen to April 2028).
+CREATE TABLE IF NOT EXISTS
+  uk_tax_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tax_year TEXT NOT NULL DEFAULT '2025/26',
+    -- Income tax
+    personal_allowance REAL NOT NULL DEFAULT 12570,
+    personal_allowance_taper_start REAL NOT NULL DEFAULT 100000,
+    basic_rate_ceiling REAL NOT NULL DEFAULT 50270,
+    higher_rate_ceiling REAL NOT NULL DEFAULT 125140,
+    basic_rate REAL NOT NULL DEFAULT 0.20,
+    higher_rate REAL NOT NULL DEFAULT 0.40,
+    additional_rate REAL NOT NULL DEFAULT 0.45,
+    -- Employee NI
+    ni_primary_threshold REAL NOT NULL DEFAULT 12570,
+    ni_upper_earnings_limit REAL NOT NULL DEFAULT 50270,
+    ni_main_rate REAL NOT NULL DEFAULT 0.08,
+    ni_upper_rate REAL NOT NULL DEFAULT 0.02,
+    -- Corporation tax and dividends (Ltd company route)
+    corporation_tax_rate REAL NOT NULL DEFAULT 0.25,
+    dividend_allowance REAL NOT NULL DEFAULT 500,
+    dividend_basic_rate REAL NOT NULL DEFAULT 0.0875,
+    dividend_higher_rate REAL NOT NULL DEFAULT 0.3375,
+    basic_rate_band REAL NOT NULL DEFAULT 37700,
+    --
+    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  uk_tax_config (tax_year)
+SELECT
+  '2025/26'
+WHERE
+  NOT EXISTS (SELECT 1 FROM uk_tax_config);
+
+-- Clear stale EUR-based exchange rates; will re-fetch with GBP base
+DELETE FROM exchange_rates;

--- a/migrations/013_uk_tax_config.sql
+++ b/migrations/013_uk_tax_config.sql
@@ -1,0 +1,41 @@
+-- Remove salary_equivalent_gbp/salary_multiplier from pricing_config
+-- (now calculated from uk_tax_config bands instead of stored)
+-- and create uk_tax_config table for HMRC tax rates.
+
+-- Drop the old column (salary_multiplier from 012, or salary_equivalent_gbp
+-- if 012 was re-run). SQLite 3.35+ supports ALTER TABLE DROP COLUMN.
+ALTER TABLE pricing_config DROP COLUMN salary_multiplier;
+
+-- UK tax bands and rates - stored in DB so they can be updated
+-- without a code deploy when HMRC changes rates.
+-- NOTE: Review annually around March/April budget.
+-- Current rates: 2025/26 tax year (frozen to April 2028).
+CREATE TABLE IF NOT EXISTS
+  uk_tax_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tax_year TEXT NOT NULL DEFAULT '2025/26',
+    personal_allowance REAL NOT NULL DEFAULT 12570,
+    personal_allowance_taper_start REAL NOT NULL DEFAULT 100000,
+    basic_rate_ceiling REAL NOT NULL DEFAULT 50270,
+    higher_rate_ceiling REAL NOT NULL DEFAULT 125140,
+    basic_rate REAL NOT NULL DEFAULT 0.20,
+    higher_rate REAL NOT NULL DEFAULT 0.40,
+    additional_rate REAL NOT NULL DEFAULT 0.45,
+    ni_primary_threshold REAL NOT NULL DEFAULT 12570,
+    ni_upper_earnings_limit REAL NOT NULL DEFAULT 50270,
+    ni_main_rate REAL NOT NULL DEFAULT 0.08,
+    ni_upper_rate REAL NOT NULL DEFAULT 0.02,
+    corporation_tax_rate REAL NOT NULL DEFAULT 0.25,
+    dividend_allowance REAL NOT NULL DEFAULT 500,
+    dividend_basic_rate REAL NOT NULL DEFAULT 0.0875,
+    dividend_higher_rate REAL NOT NULL DEFAULT 0.3375,
+    basic_rate_band REAL NOT NULL DEFAULT 37700,
+    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  uk_tax_config (tax_year)
+SELECT
+  '2025/26'
+WHERE
+  NOT EXISTS (SELECT 1 FROM uk_tax_config);

--- a/migrations/013_uk_tax_config.sql
+++ b/migrations/013_uk_tax_config.sql
@@ -1,15 +1,6 @@
--- Remove salary_equivalent_gbp/salary_multiplier from pricing_config
--- (now calculated from uk_tax_config bands instead of stored)
--- and create uk_tax_config table for HMRC tax rates.
+-- Create uk_tax_config if it doesn't exist (fresh DBs get it from 012,
+-- but DBs that ran the original 012 before it was updated need this).
 
--- Drop the old column (salary_multiplier from 012, or salary_equivalent_gbp
--- if 012 was re-run). SQLite 3.35+ supports ALTER TABLE DROP COLUMN.
-ALTER TABLE pricing_config DROP COLUMN salary_multiplier;
-
--- UK tax bands and rates - stored in DB so they can be updated
--- without a code deploy when HMRC changes rates.
--- NOTE: Review annually around March/April budget.
--- Current rates: 2025/26 tax year (frozen to April 2028).
 CREATE TABLE IF NOT EXISTS
   uk_tax_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/newsletter/2026-03-28.md
+++ b/newsletter/2026-03-28.md
@@ -4,7 +4,7 @@ date: 2026-03-28
 published: true
 ---
 
-<!-- cspell:ignore mcpick svortie Ilja -->
+<!-- cspell:ignore mcpick svortie Ilja deslop -->
 
 Right, so March was a bit of a split month. First half I was heads
 down on [Svortie](https://svortie.com) getting subscriptions and file

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,9 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			country: string | null
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -183,9 +183,16 @@ const track_analytics: Handle = async ({ event, resolve }) => {
 	return response
 }
 
+const set_country: Handle = async ({ event, resolve }) => {
+	event.locals.country =
+		event.request.headers.get('cf-ipcountry') || null
+	return await resolve(event)
+}
+
 export const handle = sequence(
 	sync_on_startup,
 	reject_suspicious_requests,
+	set_country,
 	track_analytics,
 	handle_redirects,
 	theme,

--- a/src/lib/components/landing-hero.svelte
+++ b/src/lib/components/landing-hero.svelte
@@ -31,9 +31,9 @@
 					</span>
 				</h1>
 				<p class="mb-5 text-pretty">
-					This is my blog where I write about many things, including,
-					but not limited to Svelte, SvelteKit, JavaScript, Tailwind
-					and many more web dev related topics.
+					AI engineering leader and fullstack developer. I build
+					AI-powered products with TypeScript, SvelteKit, and the
+					Claude ecosystem. I write about all of it here.
 				</p>
 				<p class="mb-5 text-pretty">
 					Check out that massive picture of my <a

--- a/src/lib/sqlite/schema.sql
+++ b/src/lib/sqlite/schema.sql
@@ -74,6 +74,64 @@ WHERE
   NOT EXISTS (SELECT 1 FROM pricing_numbers);
 
 CREATE TABLE IF NOT EXISTS
+  pricing_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    day_rate_gbp REAL NOT NULL DEFAULT 575,
+    ir35_uplift_pct REAL NOT NULL DEFAULT 25,
+    working_days_in_year INTEGER NOT NULL DEFAULT 252,
+    public_holidays INTEGER NOT NULL DEFAULT 8,
+    default_pto_days INTEGER NOT NULL DEFAULT 30,
+    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  pricing_config (
+    day_rate_gbp,
+    ir35_uplift_pct,
+    working_days_in_year,
+    public_holidays,
+    default_pto_days
+  )
+SELECT
+  575, 25, 252, 8, 30
+WHERE
+  NOT EXISTS (SELECT 1 FROM pricing_config);
+
+-- UK tax bands and rates - stored in DB so they can be updated
+-- without a code deploy when HMRC changes rates.
+-- NOTE: Review annually around March/April budget.
+-- Current rates: 2025/26 tax year (frozen to April 2028).
+CREATE TABLE IF NOT EXISTS
+  uk_tax_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tax_year TEXT NOT NULL DEFAULT '2025/26',
+    personal_allowance REAL NOT NULL DEFAULT 12570,
+    personal_allowance_taper_start REAL NOT NULL DEFAULT 100000,
+    basic_rate_ceiling REAL NOT NULL DEFAULT 50270,
+    higher_rate_ceiling REAL NOT NULL DEFAULT 125140,
+    basic_rate REAL NOT NULL DEFAULT 0.20,
+    higher_rate REAL NOT NULL DEFAULT 0.40,
+    additional_rate REAL NOT NULL DEFAULT 0.45,
+    ni_primary_threshold REAL NOT NULL DEFAULT 12570,
+    ni_upper_earnings_limit REAL NOT NULL DEFAULT 50270,
+    ni_main_rate REAL NOT NULL DEFAULT 0.08,
+    ni_upper_rate REAL NOT NULL DEFAULT 0.02,
+    corporation_tax_rate REAL NOT NULL DEFAULT 0.25,
+    dividend_allowance REAL NOT NULL DEFAULT 500,
+    dividend_basic_rate REAL NOT NULL DEFAULT 0.0875,
+    dividend_higher_rate REAL NOT NULL DEFAULT 0.3375,
+    basic_rate_band REAL NOT NULL DEFAULT 37700,
+    last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  uk_tax_config (tax_year)
+SELECT
+  '2025/26'
+WHERE
+  NOT EXISTS (SELECT 1 FROM uk_tax_config);
+
+CREATE TABLE IF NOT EXISTS
   exchange_rates (
     id INTEGER PRIMARY KEY,
     currency_code TEXT NOT NULL UNIQUE,

--- a/src/lib/state/pricing-client.svelte.ts
+++ b/src/lib/state/pricing-client.svelte.ts
@@ -1,5 +1,6 @@
 import {
 	calculate_contractor_vs_permanent,
+	DEFAULT_TAX_CONFIG,
 	type UkTaxConfig,
 } from '$lib/uk-tax-calculator'
 import { country_to_currency } from '../../routes/lets-work-together/utils'
@@ -22,25 +23,6 @@ interface PricingData {
 	exchange_rates: ExchangeRates
 	pricing_config: PricingConfig
 	uk_tax_config: UkTaxConfig
-}
-
-const DEFAULT_TAX_CONFIG: UkTaxConfig = {
-	personal_allowance: 12570,
-	personal_allowance_taper_start: 100000,
-	basic_rate_ceiling: 50270,
-	higher_rate_ceiling: 125140,
-	basic_rate: 0.2,
-	higher_rate: 0.4,
-	additional_rate: 0.45,
-	ni_primary_threshold: 12570,
-	ni_upper_earnings_limit: 50270,
-	ni_main_rate: 0.08,
-	ni_upper_rate: 0.02,
-	corporation_tax_rate: 0.25,
-	dividend_allowance: 500,
-	dividend_basic_rate: 0.0875,
-	dividend_higher_rate: 0.3375,
-	basic_rate_band: 37700,
 }
 
 class PricingState {

--- a/src/lib/state/pricing-client.svelte.ts
+++ b/src/lib/state/pricing-client.svelte.ts
@@ -1,40 +1,136 @@
+import {
+	calculate_contractor_vs_permanent,
+	type UkTaxConfig,
+} from '$lib/uk-tax-calculator'
+import { country_to_currency } from '../../routes/lets-work-together/utils'
+
 type ExchangeRates = {
-	GBP: number
+	EUR: number
 	USD: number
 	CAD: number
 }
 
-type PricingNumbers = {
-	annual_rate_eur: number
-	chosen_holidays: number
-	public_holidays: number
+type PricingConfig = {
+	day_rate_gbp: number
+	ir35_uplift_pct: number
 	working_days_in_year: number
+	public_holidays: number
+	default_pto_days: number
 }
 
 interface PricingData {
-	exchangeRates: ExchangeRates
-	pricingNumbers: PricingNumbers
+	exchange_rates: ExchangeRates
+	pricing_config: PricingConfig
+	uk_tax_config: UkTaxConfig
+}
+
+const DEFAULT_TAX_CONFIG: UkTaxConfig = {
+	personal_allowance: 12570,
+	personal_allowance_taper_start: 100000,
+	basic_rate_ceiling: 50270,
+	higher_rate_ceiling: 125140,
+	basic_rate: 0.2,
+	higher_rate: 0.4,
+	additional_rate: 0.45,
+	ni_primary_threshold: 12570,
+	ni_upper_earnings_limit: 50270,
+	ni_main_rate: 0.08,
+	ni_upper_rate: 0.02,
+	corporation_tax_rate: 0.25,
+	dividend_allowance: 500,
+	dividend_basic_rate: 0.0875,
+	dividend_higher_rate: 0.3375,
+	basic_rate_band: 37700,
 }
 
 class PricingState {
 	data = $state<PricingData>({
-		exchangeRates: { GBP: 0.86, USD: 1.09, CAD: 1.47 },
-		pricingNumbers: {
-			annual_rate_eur: 155000,
-			chosen_holidays: 30,
-			public_holidays: 8,
+		exchange_rates: { EUR: 1.17, USD: 1.27, CAD: 1.74 },
+		pricing_config: {
+			day_rate_gbp: 575,
+			ir35_uplift_pct: 25,
 			working_days_in_year: 252,
+			public_holidays: 8,
+			default_pto_days: 30,
 		},
+		uk_tax_config: { ...DEFAULT_TAX_CONFIG },
 	})
 
-	// Initialize with server data
-	init(serverData: PricingData) {
-		this.data = serverData
+	selected_currency = $state('USD')
+	pto_days = $state(30)
+	ir35_inside = $state(false)
+
+	get is_gbp(): boolean {
+		return this.selected_currency === 'GBP'
+	}
+
+	get currency_rate(): number {
+		if (this.is_gbp) return 1
+		return (
+			this.data.exchange_rates[
+				this.selected_currency as keyof ExchangeRates
+			] ?? 1
+		)
+	}
+
+	get day_rate(): number {
+		const base = this.data.pricing_config.day_rate_gbp
+		if (this.is_gbp && this.ir35_inside) {
+			return (
+				base * (1 + this.data.pricing_config.ir35_uplift_pct / 100)
+			)
+		}
+		return base
+	}
+
+	get day_rate_in_currency(): number {
+		return this.day_rate * this.currency_rate
+	}
+
+	get billable_days(): number {
+		return (
+			this.data.pricing_config.working_days_in_year -
+			this.data.pricing_config.public_holidays -
+			this.pto_days
+		)
+	}
+
+	get annual_rate(): number {
+		return this.day_rate * this.billable_days
+	}
+
+	get monthly_rate(): number {
+		return this.annual_rate / 12
+	}
+
+	get weekly_rate(): number {
+		return this.day_rate * 5
+	}
+
+	// Calculated from UK tax bands — contractor take-home vs equivalent salary
+	get tax_comparison() {
+		return calculate_contractor_vs_permanent(
+			this.data.pricing_config.day_rate_gbp,
+			this.data.pricing_config.working_days_in_year,
+			this.data.uk_tax_config,
+		)
+	}
+
+	get salary_equivalent(): number {
+		return this.tax_comparison.equivalent_permanent.gross
+	}
+
+	get contractor_take_home(): number {
+		return this.tax_comparison.contractor.take_home
+	}
+
+	init(server_data: PricingData, country: string | null) {
+		this.data = server_data
+		this.pto_days = server_data.pricing_config.default_pto_days
+		this.selected_currency = country_to_currency(country)
 	}
 }
 
-// Single universal instance shared everywhere
 export const pricing_state = new PricingState()
 
-// Export types
-export type { ExchangeRates, PricingData, PricingNumbers }
+export type { ExchangeRates, PricingConfig, PricingData }

--- a/src/lib/state/pricing.svelte.ts
+++ b/src/lib/state/pricing.svelte.ts
@@ -6,37 +6,69 @@ import {
 	set_cache,
 } from '$lib/cache/server-cache'
 import { sqlite_client } from '$lib/sqlite/client'
+import type { UkTaxConfig } from '$lib/uk-tax-calculator'
 import { differenceInHours, parseISO } from 'date-fns'
 
-const CACHE_KEY = 'pricing'
+const CACHE_KEY = 'pricing_v3'
 
 type ExchangeRates = {
-	GBP: number
+	EUR: number
 	USD: number
 	CAD: number
 }
 
-type PricingNumbers = {
-	annual_rate_eur: number
-	chosen_holidays: number
-	public_holidays: number
+type PricingConfig = {
+	day_rate_gbp: number
+	ir35_uplift_pct: number
 	working_days_in_year: number
+	public_holidays: number
+	default_pto_days: number
 }
 
 interface PricingData {
-	exchangeRates: ExchangeRates
-	pricingNumbers: PricingNumbers
+	exchange_rates: ExchangeRates
+	pricing_config: PricingConfig
+	uk_tax_config: UkTaxConfig
+}
+
+const DEFAULT_CONFIG: PricingConfig = {
+	day_rate_gbp: 575,
+	ir35_uplift_pct: 25,
+	working_days_in_year: 252,
+	public_holidays: 8,
+	default_pto_days: 30,
+}
+
+const DEFAULT_TAX_CONFIG: UkTaxConfig = {
+	personal_allowance: 12570,
+	personal_allowance_taper_start: 100000,
+	basic_rate_ceiling: 50270,
+	higher_rate_ceiling: 125140,
+	basic_rate: 0.2,
+	higher_rate: 0.4,
+	additional_rate: 0.45,
+	ni_primary_threshold: 12570,
+	ni_upper_earnings_limit: 50270,
+	ni_main_rate: 0.08,
+	ni_upper_rate: 0.02,
+	corporation_tax_rate: 0.25,
+	dividend_allowance: 500,
+	dividend_basic_rate: 0.0875,
+	dividend_higher_rate: 0.3375,
+	basic_rate_band: 37700,
+}
+
+const FALLBACK_RATES: ExchangeRates = {
+	EUR: 1.17,
+	USD: 1.27,
+	CAD: 1.74,
 }
 
 class PricingState {
 	data = $state<PricingData>({
-		exchangeRates: { GBP: 0, USD: 0, CAD: 0 },
-		pricingNumbers: {
-			annual_rate_eur: 155000,
-			chosen_holidays: 30,
-			public_holidays: 8,
-			working_days_in_year: 252,
-		},
+		exchange_rates: { ...FALLBACK_RATES },
+		pricing_config: { ...DEFAULT_CONFIG },
+		uk_tax_config: { ...DEFAULT_TAX_CONFIG },
 	})
 	loading = $state<boolean>(false)
 	last_fetched = $state<number>(0)
@@ -44,18 +76,13 @@ class PricingState {
 	async load_pricing_data(): Promise<void> {
 		if (BYPASS_DB_READS.pricing) {
 			this.data = {
-				exchangeRates: { GBP: 0.86, USD: 1.09, CAD: 1.47 },
-				pricingNumbers: {
-					annual_rate_eur: 155000,
-					chosen_holidays: 30,
-					public_holidays: 8,
-					working_days_in_year: 252,
-				},
+				exchange_rates: { ...FALLBACK_RATES },
+				pricing_config: { ...DEFAULT_CONFIG },
+				uk_tax_config: { ...DEFAULT_TAX_CONFIG },
 			}
-			return // DB reads disabled
+			return
 		}
 
-		// Check server cache first
 		const server_cached = get_from_cache<PricingData>(
 			CACHE_KEY,
 			CACHE_DURATIONS.pricing,
@@ -66,31 +93,28 @@ class PricingState {
 			return
 		}
 
-		// Check client cache
 		if (
 			Date.now() - this.last_fetched < CACHE_DURATIONS.pricing &&
-			this.data.exchangeRates.USD > 0 &&
-			this.data.pricingNumbers.annual_rate_eur > 0
+			this.data.exchange_rates.USD > 0 &&
+			this.data.pricing_config.day_rate_gbp > 0
 		) {
-			return // Use cached data
+			return
 		}
 
-		if (this.loading) return // Prevent concurrent requests
+		if (this.loading) return
 
 		this.loading = true
 
 		try {
-			const [exchangeRates, pricingNumbers] = await Promise.all([
-				this.fetch_exchange_rates(),
-				this.fetch_pricing_numbers(),
-			])
+			const [exchange_rates, pricing_config, uk_tax_config] =
+				await Promise.all([
+					this.fetch_exchange_rates(),
+					this.fetch_pricing_config(),
+					this.fetch_uk_tax_config(),
+				])
 
-			const data = {
-				exchangeRates,
-				pricingNumbers,
-			}
+			const data = { exchange_rates, pricing_config, uk_tax_config }
 
-			// Update both caches
 			this.data = data
 			this.last_fetched = Date.now()
 			set_cache(CACHE_KEY, data)
@@ -99,7 +123,6 @@ class PricingState {
 				'Database unavailable, keeping cached pricing data:',
 				error instanceof Error ? error.message : 'Unknown error',
 			)
-			// Keep existing data on error - don't clear it
 		} finally {
 			this.loading = false
 		}
@@ -109,17 +132,16 @@ class PricingState {
 		const client = sqlite_client
 		let fetch_new_rates = false
 
-		// Check if the rates in the database are outdated
 		try {
 			const last_update_result = await client.execute(
 				'SELECT MAX(last_updated) as last_update FROM exchange_rates;',
 			)
 			const last_updated = last_update_result.rows[0] as unknown as {
-				last_update: string
+				last_update: string | null
 			}
 
 			if (
-				last_updated &&
+				!last_updated?.last_update ||
 				differenceInHours(
 					new Date(),
 					parseISO(last_updated.last_update),
@@ -132,43 +154,51 @@ class PricingState {
 				'Database unavailable for checking rates update time, will use fallbacks:',
 				error instanceof Error ? error.message : 'Unknown error',
 			)
-			// When database is unavailable, skip fetching new rates and use fallbacks
-			return { GBP: 0.86, USD: 1.09, CAD: 1.47 }
+			return { ...FALLBACK_RATES }
 		}
 
-		// Fetch new rates if necessary and update the database
 		if (fetch_new_rates) {
-			const response = await fetch(
-				`https://api.freecurrencyapi.com/v1/latest?apikey=${EXCHANGE_RATE_API_KEY}&currencies=GBP%2CUSD%2CCAD&base_currency=EUR`,
-			)
-			const fetched_rates = (await response.json())
-				.data as ExchangeRates
+			try {
+				const response = await fetch(
+					`https://api.freecurrencyapi.com/v1/latest?apikey=${EXCHANGE_RATE_API_KEY}&currencies=EUR%2CUSD%2CCAD&base_currency=GBP`,
+				)
+				const fetched_rates = (await response.json())
+					.data as ExchangeRates
 
-			for (const [currency, rate] of Object.entries(fetched_rates)) {
-				try {
-					// TODO: Maybe keep a history of these?
-					const stmt =
-						client.prepare(`INSERT INTO exchange_rates (currency_code, rate) VALUES (?, ?)
-							ON CONFLICT (currency_code) DO UPDATE SET rate = ?, last_updated = CURRENT_TIMESTAMP;`)
-					stmt.run(currency, rate, rate)
-				} catch (error) {
-					console.error(
-						`Error updating exchange rate for ${currency}:`,
-						error,
-					)
+				for (const [currency, rate] of Object.entries(
+					fetched_rates,
+				)) {
+					try {
+						const stmt = client.prepare(
+							`INSERT INTO exchange_rates (currency_code, rate) VALUES (?, ?)
+							ON CONFLICT (currency_code) DO UPDATE SET rate = ?, last_updated = CURRENT_TIMESTAMP;`,
+						)
+						stmt.run(currency, rate, rate)
+					} catch (error) {
+						console.error(
+							`Error updating exchange rate for ${currency}:`,
+							error,
+						)
+					}
 				}
+			} catch (error) {
+				console.warn(
+					'Failed to fetch exchange rates from API:',
+					error instanceof Error ? error.message : 'Unknown error',
+				)
 			}
 		}
 
-		// If the rates are not outdated, fetch them from the database
 		try {
 			const result = await client.execute(
 				'SELECT currency_code, rate FROM exchange_rates;',
 			)
-			const rates: ExchangeRates = { GBP: 0, USD: 0, CAD: 0 }
+			const rates: ExchangeRates = { ...FALLBACK_RATES }
 			result.rows.forEach((row) => {
 				const code = row.currency_code as keyof ExchangeRates
-				rates[code] = Number(row.rate)
+				if (code in rates) {
+					rates[code] = Number(row.rate)
+				}
 			})
 			return rates
 		} catch (error) {
@@ -176,58 +206,87 @@ class PricingState {
 				'Database unavailable for exchange rates, using fallbacks:',
 				error instanceof Error ? error.message : 'Unknown error',
 			)
-			return { GBP: 0.86, USD: 1.09, CAD: 1.47 } // Fallback rates
+			return { ...FALLBACK_RATES }
 		}
 	}
 
-	private async fetch_pricing_numbers(): Promise<PricingNumbers> {
+	private async fetch_pricing_config(): Promise<PricingConfig> {
 		const client = sqlite_client
-		let pricing_numbers: any
 
 		try {
-			pricing_numbers = await client.execute(
-				'SELECT * FROM pricing_numbers ORDER BY last_updated DESC LIMIT 1;',
+			const result = await client.execute(
+				'SELECT * FROM pricing_config ORDER BY last_updated DESC LIMIT 1;',
 			)
 
-			if (pricing_numbers.rows.length === 0) {
-				return {
-					annual_rate_eur: 155000,
-					chosen_holidays: 30,
-					public_holidays: 8,
-					working_days_in_year: 252,
-				}
+			if (result.rows.length === 0) {
+				return { ...DEFAULT_CONFIG }
 			}
 
-			const row = pricing_numbers.rows[0]
+			const row = result.rows[0]
 			return {
-				annual_rate_eur: Number(row.annual_rate_eur),
-				chosen_holidays: Number(row.chosen_holidays),
-				public_holidays: Number(row.public_holidays),
+				day_rate_gbp: Number(row.day_rate_gbp),
+				ir35_uplift_pct: Number(row.ir35_uplift_pct),
 				working_days_in_year: Number(row.working_days_in_year),
+				public_holidays: Number(row.public_holidays),
+				default_pto_days: Number(row.default_pto_days),
 			}
 		} catch (error) {
 			console.warn(
-				'Database unavailable for pricing numbers, using defaults:',
+				'Database unavailable for pricing config, using defaults:',
 				error instanceof Error ? error.message : 'Unknown error',
 			)
-			return {
-				annual_rate_eur: 155000,
-				chosen_holidays: 30,
-				public_holidays: 8,
-				working_days_in_year: 252,
+			return { ...DEFAULT_CONFIG }
+		}
+	}
+
+	private async fetch_uk_tax_config(): Promise<UkTaxConfig> {
+		const client = sqlite_client
+
+		try {
+			const result = await client.execute(
+				'SELECT * FROM uk_tax_config ORDER BY last_updated DESC LIMIT 1;',
+			)
+
+			if (result.rows.length === 0) {
+				return { ...DEFAULT_TAX_CONFIG }
 			}
+
+			const row = result.rows[0]
+			return {
+				personal_allowance: Number(row.personal_allowance),
+				personal_allowance_taper_start: Number(
+					row.personal_allowance_taper_start,
+				),
+				basic_rate_ceiling: Number(row.basic_rate_ceiling),
+				higher_rate_ceiling: Number(row.higher_rate_ceiling),
+				basic_rate: Number(row.basic_rate),
+				higher_rate: Number(row.higher_rate),
+				additional_rate: Number(row.additional_rate),
+				ni_primary_threshold: Number(row.ni_primary_threshold),
+				ni_upper_earnings_limit: Number(row.ni_upper_earnings_limit),
+				ni_main_rate: Number(row.ni_main_rate),
+				ni_upper_rate: Number(row.ni_upper_rate),
+				corporation_tax_rate: Number(row.corporation_tax_rate),
+				dividend_allowance: Number(row.dividend_allowance),
+				dividend_basic_rate: Number(row.dividend_basic_rate),
+				dividend_higher_rate: Number(row.dividend_higher_rate),
+				basic_rate_band: Number(row.basic_rate_band),
+			}
+		} catch (error) {
+			console.warn(
+				'Database unavailable for UK tax config, using defaults:',
+				error instanceof Error ? error.message : 'Unknown error',
+			)
+			return { ...DEFAULT_TAX_CONFIG }
 		}
 	}
 }
 
-// Single universal instance shared everywhere
 export const pricing_state = new PricingState()
 
-// Server-side function that uses the pricing state instance
 export const get_pricing_data = async (): Promise<PricingData> => {
 	await pricing_state.load_pricing_data()
 	return pricing_state.data
 }
 
-// Export types
-export type { ExchangeRates, PricingData, PricingNumbers }
+export type { ExchangeRates, PricingConfig, PricingData }

--- a/src/lib/state/pricing.svelte.ts
+++ b/src/lib/state/pricing.svelte.ts
@@ -6,7 +6,10 @@ import {
 	set_cache,
 } from '$lib/cache/server-cache'
 import { sqlite_client } from '$lib/sqlite/client'
-import type { UkTaxConfig } from '$lib/uk-tax-calculator'
+import {
+	DEFAULT_TAX_CONFIG,
+	type UkTaxConfig,
+} from '$lib/uk-tax-calculator'
 import { differenceInHours, parseISO } from 'date-fns'
 
 const CACHE_KEY = 'pricing_v3'
@@ -37,25 +40,6 @@ const DEFAULT_CONFIG: PricingConfig = {
 	working_days_in_year: 252,
 	public_holidays: 8,
 	default_pto_days: 30,
-}
-
-const DEFAULT_TAX_CONFIG: UkTaxConfig = {
-	personal_allowance: 12570,
-	personal_allowance_taper_start: 100000,
-	basic_rate_ceiling: 50270,
-	higher_rate_ceiling: 125140,
-	basic_rate: 0.2,
-	higher_rate: 0.4,
-	additional_rate: 0.45,
-	ni_primary_threshold: 12570,
-	ni_upper_earnings_limit: 50270,
-	ni_main_rate: 0.08,
-	ni_upper_rate: 0.02,
-	corporation_tax_rate: 0.25,
-	dividend_allowance: 500,
-	dividend_basic_rate: 0.0875,
-	dividend_higher_rate: 0.3375,
-	basic_rate_band: 37700,
 }
 
 const FALLBACK_RATES: ExchangeRates = {

--- a/src/lib/uk-tax-calculator.test.ts
+++ b/src/lib/uk-tax-calculator.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import {
+	calculate_contractor_take_home,
+	calculate_contractor_vs_permanent,
+	calculate_gross_from_take_home,
+	calculate_permanent_take_home,
+	DEFAULT_TAX_CONFIG,
+} from './uk-tax-calculator'
+
+const config = DEFAULT_TAX_CONFIG
+
+describe('calculate_permanent_take_home', () => {
+	it('returns full salary when below personal allowance', () => {
+		const result = calculate_permanent_take_home(10000, config)
+		expect(result.income_tax).toBe(0)
+		expect(result.employee_ni).toBe(0)
+		expect(result.take_home).toBe(10000)
+	})
+
+	it('calculates basic rate correctly', () => {
+		const result = calculate_permanent_take_home(30000, config)
+		// Taxable: 30000 - 12570 = 17430
+		// Tax: 17430 * 0.2 = 3486
+		expect(result.income_tax).toBe(3486)
+		expect(result.personal_allowance).toBe(12570)
+	})
+
+	it('calculates higher rate correctly', () => {
+		const result = calculate_permanent_take_home(80000, config)
+		// Basic: (50270 - 12570) * 0.2 = 7540
+		// Higher: (80000 - 50270) * 0.4 = 11892
+		expect(result.income_tax).toBe(7540 + 11892)
+	})
+
+	it('tapers personal allowance above 100k', () => {
+		const result = calculate_permanent_take_home(110000, config)
+		// Excess: 110000 - 100000 = 10000, lose 5000 PA
+		expect(result.personal_allowance).toBe(12570 - 5000)
+	})
+
+	it('removes personal allowance entirely above 125140', () => {
+		const result = calculate_permanent_take_home(130000, config)
+		expect(result.personal_allowance).toBe(0)
+	})
+
+	it('calculates additional rate above 125140', () => {
+		const result = calculate_permanent_take_home(150000, config)
+		expect(result.personal_allowance).toBe(0)
+		// Has basic + higher + additional components
+		expect(result.income_tax).toBeGreaterThan(40000)
+	})
+
+	it('calculates employee NI correctly', () => {
+		const result = calculate_permanent_take_home(60000, config)
+		// Main: (50270 - 12570) * 0.08 = 3016
+		// Upper: (60000 - 50270) * 0.02 = 194.60
+		expect(result.employee_ni).toBeCloseTo(3016 + 194.6, 0)
+	})
+})
+
+describe('calculate_contractor_take_home', () => {
+	it('uses personal allowance as salary', () => {
+		const result = calculate_contractor_take_home(100000, config)
+		expect(result.salary).toBe(12570)
+	})
+
+	it('applies corporation tax at 25%', () => {
+		const result = calculate_contractor_take_home(100000, config)
+		const profit = 100000 - 12570
+		expect(result.corporation_tax).toBe(
+			Math.round(profit * 0.25 * 100) / 100,
+		)
+	})
+
+	it('calculates realistic take-home for 575/day', () => {
+		const result = calculate_contractor_take_home(575 * 252, config)
+		// Should be roughly 87-90k
+		expect(result.take_home).toBeGreaterThan(85000)
+		expect(result.take_home).toBeLessThan(92000)
+	})
+})
+
+describe('calculate_gross_from_take_home', () => {
+	it('finds gross that produces target take-home', () => {
+		const target = 70000
+		const result = calculate_gross_from_take_home(target, config)
+		expect(result.take_home).toBeCloseTo(target, 0)
+	})
+
+	it('handles the 60% trap zone correctly', () => {
+		// Someone wanting 80k take-home needs to earn in the trap zone
+		const result = calculate_gross_from_take_home(80000, config)
+		expect(result.gross).toBeGreaterThan(120000)
+		expect(result.take_home).toBeCloseTo(80000, 0)
+	})
+})
+
+describe('calculate_contractor_vs_permanent', () => {
+	it('produces matching take-home for both routes', () => {
+		const result = calculate_contractor_vs_permanent(575, 252, config)
+		// Binary search gets within £1 precision
+		expect(
+			Math.abs(
+				result.contractor.take_home -
+					result.equivalent_permanent.take_home,
+			),
+		).toBeLessThan(2)
+	})
+
+	it('equivalent salary is less than contractor gross', () => {
+		const result = calculate_contractor_vs_permanent(575, 252, config)
+		// Contractor gross: 144900
+		// Equivalent salary should be less (tax efficiency of Ltd route)
+		expect(result.equivalent_permanent.gross).toBeLessThan(
+			result.contractor.gross_annual,
+		)
+	})
+
+	it('uses correct gross annual', () => {
+		const result = calculate_contractor_vs_permanent(575, 252, config)
+		expect(result.contractor.gross_annual).toBe(575 * 252)
+	})
+})

--- a/src/lib/uk-tax-calculator.ts
+++ b/src/lib/uk-tax-calculator.ts
@@ -22,6 +22,28 @@ export interface UkTaxConfig {
 	basic_rate_band: number
 }
 
+// Fallback defaults matching uk_tax_config table defaults.
+// The DB is the source of truth — these only apply if the DB
+// is unavailable. Update both when rates change.
+export const DEFAULT_TAX_CONFIG: UkTaxConfig = {
+	personal_allowance: 12570,
+	personal_allowance_taper_start: 100000,
+	basic_rate_ceiling: 50270,
+	higher_rate_ceiling: 125140,
+	basic_rate: 0.2,
+	higher_rate: 0.4,
+	additional_rate: 0.45,
+	ni_primary_threshold: 12570,
+	ni_upper_earnings_limit: 50270,
+	ni_main_rate: 0.08,
+	ni_upper_rate: 0.02,
+	corporation_tax_rate: 0.25,
+	dividend_allowance: 500,
+	dividend_basic_rate: 0.0875,
+	dividend_higher_rate: 0.3375,
+	basic_rate_band: 37700,
+}
+
 export interface PermanentBreakdown {
 	gross: number
 	personal_allowance: number

--- a/src/lib/uk-tax-calculator.ts
+++ b/src/lib/uk-tax-calculator.ts
@@ -1,0 +1,261 @@
+// UK Tax Calculator
+// Tax bands are loaded from the uk_tax_config DB table.
+// NOTE: Check and update uk_tax_config annually around March/April
+// budget. Current rates: 2025/26 (frozen to April 2028).
+
+export interface UkTaxConfig {
+	personal_allowance: number
+	personal_allowance_taper_start: number
+	basic_rate_ceiling: number
+	higher_rate_ceiling: number
+	basic_rate: number
+	higher_rate: number
+	additional_rate: number
+	ni_primary_threshold: number
+	ni_upper_earnings_limit: number
+	ni_main_rate: number
+	ni_upper_rate: number
+	corporation_tax_rate: number
+	dividend_allowance: number
+	dividend_basic_rate: number
+	dividend_higher_rate: number
+	basic_rate_band: number
+}
+
+export interface PermanentBreakdown {
+	gross: number
+	personal_allowance: number
+	income_tax: number
+	employee_ni: number
+	total_deductions: number
+	take_home: number
+}
+
+export interface ContractorBreakdown {
+	gross_annual: number
+	salary: number
+	corporation_tax: number
+	dividends: number
+	dividend_tax: number
+	salary_income_tax: number
+	salary_ni: number
+	total_tax: number
+	take_home: number
+}
+
+export interface ContractorVsPermanent {
+	day_rate: number
+	working_days: number
+	contractor: ContractorBreakdown
+	equivalent_permanent: PermanentBreakdown
+}
+
+const effective_personal_allowance = (
+	gross: number,
+	config: UkTaxConfig,
+): number => {
+	if (gross <= config.personal_allowance_taper_start) {
+		return config.personal_allowance
+	}
+	const taper_end =
+		config.personal_allowance_taper_start +
+		config.personal_allowance * 2
+	if (gross >= taper_end) return 0
+	const excess = gross - config.personal_allowance_taper_start
+	return Math.max(
+		0,
+		config.personal_allowance - Math.floor(excess / 2),
+	)
+}
+
+const calculate_income_tax = (
+	gross: number,
+	config: UkTaxConfig,
+): number => {
+	const allowance = effective_personal_allowance(gross, config)
+	const taxable = Math.max(0, gross - allowance)
+
+	let tax = 0
+	const basic_band = Math.max(
+		0,
+		config.basic_rate_ceiling - allowance,
+	)
+	const higher_band =
+		config.higher_rate_ceiling - config.basic_rate_ceiling
+
+	if (taxable <= basic_band) {
+		tax = taxable * config.basic_rate
+	} else if (taxable <= basic_band + higher_band) {
+		tax = basic_band * config.basic_rate
+		tax += (taxable - basic_band) * config.higher_rate
+	} else {
+		tax = basic_band * config.basic_rate
+		tax += higher_band * config.higher_rate
+		tax +=
+			(taxable - basic_band - higher_band) * config.additional_rate
+	}
+
+	return Math.round(tax * 100) / 100
+}
+
+const calculate_employee_ni = (
+	gross: number,
+	config: UkTaxConfig,
+): number => {
+	if (gross <= config.ni_primary_threshold) return 0
+
+	let ni = 0
+	const main_band =
+		Math.min(gross, config.ni_upper_earnings_limit) -
+		config.ni_primary_threshold
+	ni += main_band * config.ni_main_rate
+
+	if (gross > config.ni_upper_earnings_limit) {
+		ni +=
+			(gross - config.ni_upper_earnings_limit) * config.ni_upper_rate
+	}
+
+	return Math.round(ni * 100) / 100
+}
+
+export const calculate_permanent_take_home = (
+	gross: number,
+	config: UkTaxConfig,
+): PermanentBreakdown => {
+	const allowance = effective_personal_allowance(gross, config)
+	const income_tax = calculate_income_tax(gross, config)
+	const employee_ni = calculate_employee_ni(gross, config)
+	const total_deductions = income_tax + employee_ni
+
+	return {
+		gross: Math.round(gross * 100) / 100,
+		personal_allowance: allowance,
+		income_tax,
+		employee_ni,
+		total_deductions: Math.round(total_deductions * 100) / 100,
+		take_home: Math.round((gross - total_deductions) * 100) / 100,
+	}
+}
+
+const calculate_dividend_tax = (
+	dividends: number,
+	salary: number,
+	config: UkTaxConfig,
+): number => {
+	if (dividends <= 0) return 0
+
+	const salary_taxable = Math.max(
+		0,
+		salary - config.personal_allowance,
+	)
+	const remaining_basic_band = Math.max(
+		0,
+		config.basic_rate_band - salary_taxable,
+	)
+
+	let tax = 0
+	let remaining = dividends
+
+	const allowance_used = Math.min(
+		remaining,
+		config.dividend_allowance,
+	)
+	remaining -= allowance_used
+
+	const basic_rate_space = Math.max(
+		0,
+		remaining_basic_band - allowance_used,
+	)
+	const basic_dividends = Math.min(remaining, basic_rate_space)
+	tax += basic_dividends * config.dividend_basic_rate
+	remaining -= basic_dividends
+
+	if (remaining > 0) {
+		tax += remaining * config.dividend_higher_rate
+	}
+
+	return Math.round(tax * 100) / 100
+}
+
+export const calculate_contractor_take_home = (
+	gross_annual: number,
+	config: UkTaxConfig,
+): ContractorBreakdown => {
+	const salary = config.personal_allowance
+	const profit = Math.max(0, gross_annual - salary)
+	const corporation_tax = profit * config.corporation_tax_rate
+	const dividends = profit - corporation_tax
+
+	const salary_income_tax = calculate_income_tax(salary, config)
+	const salary_ni = calculate_employee_ni(salary, config)
+	const dividend_tax = calculate_dividend_tax(
+		dividends,
+		salary,
+		config,
+	)
+
+	const total_tax =
+		corporation_tax + salary_income_tax + salary_ni + dividend_tax
+
+	return {
+		gross_annual: Math.round(gross_annual * 100) / 100,
+		salary,
+		corporation_tax: Math.round(corporation_tax * 100) / 100,
+		dividends: Math.round(dividends * 100) / 100,
+		dividend_tax,
+		salary_income_tax,
+		salary_ni,
+		total_tax: Math.round(total_tax * 100) / 100,
+		take_home: Math.round((gross_annual - total_tax) * 100) / 100,
+	}
+}
+
+// Reverse: find gross salary that gives target take-home (binary search)
+export const calculate_gross_from_take_home = (
+	target_take_home: number,
+	config: UkTaxConfig,
+): PermanentBreakdown => {
+	let low = target_take_home
+	let high = target_take_home * 3
+
+	for (let i = 0; i < 100; i++) {
+		const mid = (low + high) / 2
+		const result = calculate_permanent_take_home(mid, config)
+
+		if (Math.abs(result.take_home - target_take_home) < 1) {
+			return result
+		}
+
+		if (result.take_home < target_take_home) {
+			low = mid
+		} else {
+			high = mid
+		}
+	}
+
+	return calculate_permanent_take_home((low + high) / 2, config)
+}
+
+// Full comparison: day rate -> contractor take-home -> equivalent salary
+export const calculate_contractor_vs_permanent = (
+	day_rate: number,
+	working_days: number,
+	config: UkTaxConfig,
+): ContractorVsPermanent => {
+	const gross_annual = day_rate * working_days
+	const contractor = calculate_contractor_take_home(
+		gross_annual,
+		config,
+	)
+	const equivalent_permanent = calculate_gross_from_take_home(
+		contractor.take_home,
+		config,
+	)
+
+	return {
+		day_rate,
+		working_days,
+		contractor,
+		equivalent_permanent,
+	}
+}

--- a/src/routes/api/ingest/+server.ts
+++ b/src/routes/api/ingest/+server.ts
@@ -42,11 +42,18 @@ curl -X POST https://scottspence.com/api/ingest \
 	-H "Authorization: Bearer $INGEST_TOKEN" \
 	-d '{"task": "backup_database"}'
  *
- * Step 3: Download the backup to local
+ * Step 3: Back up local DB (if exists), then download production
  *
+ * IMPORTANT: Always back up the local DB before overwriting.
+ * Downloading over a running DB can corrupt it.
+ *
+# Stop dev server first, then:
+[ -f data/site-data.db ] && cp data/site-data.db data/site-data.db.bak
+rm -f data/site-data.db
 curl -H "Authorization: Bearer $INGEST_TOKEN" \
 		https://scottspence.com/api/ingest/download \
 		-o data/site-data.db
+# If download fails, restore: cp data/site-data.db.bak data/site-data.db
  *
  * Step 4: Restart dev server to clear caches
  *

--- a/src/routes/lets-work-together/+page.server.ts
+++ b/src/routes/lets-work-together/+page.server.ts
@@ -1,10 +1,14 @@
 import { get_pricing_data } from '$lib/state/pricing.svelte'
+import type { ServerLoadEvent } from '@sveltejs/kit'
 
-export const load = async () => {
-	const { exchangeRates, pricingNumbers } = await get_pricing_data()
+export const load = async ({ locals }: ServerLoadEvent) => {
+	const { exchange_rates, pricing_config, uk_tax_config } =
+		await get_pricing_data()
 
 	return {
-		exchange_rates: exchangeRates,
-		pricing_numbers: pricingNumbers,
+		exchange_rates,
+		pricing_config,
+		uk_tax_config,
+		country: locals.country,
 	}
 }

--- a/src/routes/lets-work-together/+page.svelte
+++ b/src/routes/lets-work-together/+page.svelte
@@ -17,25 +17,17 @@
 
 	let { data }: Props = $props()
 	let Copy = $derived(data.Copy)
-	let exchange_rates = $derived(data.exchange_rates)
-	let pricing_numbers = $derived(data.pricing_numbers)
 
-	// Initialize client-side state with server data
-	$effect(() => {
-		pricing_state.init({
-			exchangeRates: exchange_rates,
-			pricingNumbers: pricing_numbers || {
-				posts_per_week: 1,
-				years_programming: 10,
-				total_posts: 100,
-				average_reading_time: 5,
-				annual_rate_eur: 120000,
-				chosen_holidays: 25,
-				working_days_in_year: 260,
-				public_holidays: 8,
-			},
-		})
-	})
+	// Initialise client-side state with server data (one-time hydration)
+	// svelte-ignore state_referenced_locally
+	pricing_state.init(
+		{
+			exchange_rates: data.exchange_rates,
+			pricing_config: data.pricing_config,
+			uk_tax_config: data.uk_tax_config,
+		},
+		data.country,
+	)
 
 	let end_of_copy = $state<HTMLElement | null>(null)
 	let show_table_of_contents = $state(true)

--- a/src/routes/lets-work-together/blog-post.svelte
+++ b/src/routes/lets-work-together/blog-post.svelte
@@ -1,97 +1,40 @@
 <script lang="ts">
 	import { pricing_state } from '$lib/state/pricing-client.svelte'
-	import CurrencySelect from './currency-select.svelte'
 	import Select from './select.svelte'
-	import { calculate_day_rate_with_pto, locale_string } from './utils'
-
-	const get_field_value = (field_name: string): number => {
-		return (
-			pricing_state.data.pricingNumbers[
-				field_name as keyof typeof pricing_state.data.pricingNumbers
-			] || 0
-		)
-	}
-
-	let annual_rate_EUR = get_field_value('annual_rate_eur') || 120000
-	let working_days_in_year =
-		get_field_value('working_days_in_year') || 260
+	import { locale_string } from './utils'
 
 	const BLOG_POST_LENGTH = {
-		Short: {
-			description: '<1k words',
-			cost:
-				calculate_day_rate_with_pto(
-					annual_rate_EUR,
-					working_days_in_year,
-				) * 1,
-		},
-		Medium: {
-			description: '1k-2k words',
-			cost:
-				calculate_day_rate_with_pto(
-					annual_rate_EUR,
-					working_days_in_year,
-				) * 2,
-		},
-		Long: {
-			description: '>2k words',
-			cost:
-				calculate_day_rate_with_pto(
-					annual_rate_EUR,
-					working_days_in_year,
-				) * 3,
-		},
+		Short: { description: '<1k words', multiplier: 1 },
+		Medium: { description: '1k-2k words', multiplier: 2 },
+		Long: { description: '>2k words', multiplier: 3 },
 	}
 
 	const BLOG_POST_DEPTH = {
 		Overview: 0,
-		'In-depth': 0.5, // 50% extra
-		Series: 0.4, // 40% extra
+		'In-depth': 0.5,
+		Series: 0.4,
 	}
 
 	let selected_post_length = $state(Object.keys(BLOG_POST_LENGTH)[0])
 	let selected_post_depth = $state(Object.keys(BLOG_POST_DEPTH)[0])
-	let selected_currency = $state('EUR')
-	let selected_length_description = $state('Short')
 
-	// function to calculate cost with depth
-	const calculate_cost_with_depth = (
-		base_cost: number,
-		depth_percentage: number,
-	) => base_cost * (1 + depth_percentage)
-
-	$effect.pre(() => {
-		selected_length_description =
-			BLOG_POST_LENGTH[
-				selected_post_length as keyof typeof BLOG_POST_LENGTH
-			].description
-	})
-
-	let post_cost = $derived(
+	let selected_length_config = $derived(
 		BLOG_POST_LENGTH[
 			selected_post_length as keyof typeof BLOG_POST_LENGTH
-		].cost,
+		],
 	)
 
-	let post_cost_with_depth = $derived(
-		calculate_cost_with_depth(
-			post_cost,
-			BLOG_POST_DEPTH[
-				selected_post_depth as keyof typeof BLOG_POST_DEPTH
-			],
-		),
+	let depth_multiplier = $derived(
+		BLOG_POST_DEPTH[
+			selected_post_depth as keyof typeof BLOG_POST_DEPTH
+		],
 	)
 
-	let currency_rate = $derived(
-		selected_currency === 'EUR'
-			? 1
-			: pricing_state.data.exchangeRates[
-					selected_currency as keyof typeof pricing_state.data.exchangeRates
-				],
-	)
-
-	let post_cost_with_depth_in_selected_currency = $derived(
-		post_cost_with_depth * currency_rate,
+	let total_cost = $derived(
+		pricing_state.day_rate *
+			selected_length_config.multiplier *
+			(1 + depth_multiplier) *
+			pricing_state.currency_rate,
 	)
 </script>
 
@@ -120,10 +63,6 @@
 						options={Object.keys(BLOG_POST_DEPTH)}
 					/>
 				</div>
-
-				<div class="mb-4">
-					<CurrencySelect bind:selected_currency />
-				</div>
 			</fieldset>
 
 			<div
@@ -133,7 +72,7 @@
 				<div class="stat">
 					<div class="stat-title font-medium">Length</div>
 					<div class="stat-value text-primary flex items-center">
-						{selected_length_description}
+						{selected_length_config.description}
 					</div>
 					<div class="stat-desc">Word count range</div>
 				</div>
@@ -157,9 +96,9 @@
 				<div class="stat">
 					<div class="stat-title font-medium">Total</div>
 					<div class="stat-value text-accent flex items-center">
-						{locale_string(post_cost_with_depth_in_selected_currency)}
+						{locale_string(total_cost)}
 						<span class="ml-2 text-xl">
-							{selected_currency}
+							{pricing_state.selected_currency}
 						</span>
 					</div>
 					<div class="stat-desc">Final price</div>

--- a/src/routes/lets-work-together/currency-select.svelte
+++ b/src/routes/lets-work-together/currency-select.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
 	import { pricing_state } from '$lib/state/pricing-client.svelte'
-	let { selected_currency = $bindable('EUR') } = $props()
 </script>
 
-<legend class="sr-only">Currency Selection</legend>
-<label for="selected_currency" class="label">
-	<span class="text-base font-medium">Currency:</span>
-</label>
-<select
-	id="selected_currency"
-	bind:value={selected_currency}
-	class="select select-sm rounded-box w-full text-sm"
->
-	<option class="text-base-content" value="EUR">EUR</option>
-	{#each Object.keys(pricing_state.data.exchangeRates || {}) as currency}
-		<option class="text-base-content" value={currency}>
-			{currency}
-		</option>
-	{/each}
-</select>
+<fieldset>
+	<legend class="sr-only">Currency Selection</legend>
+	<label for="selected_currency" class="label">
+		<span class="text-base font-medium">Currency:</span>
+	</label>
+	<select
+		id="selected_currency"
+		bind:value={pricing_state.selected_currency}
+		class="select select-sm rounded-box w-full text-sm"
+	>
+		<option class="text-base-content" value="GBP">GBP</option>
+		{#each Object.keys(pricing_state.data.exchange_rates || {}) as currency}
+			<option class="text-base-content" value={currency}>
+				{currency}
+			</option>
+		{/each}
+	</select>
+</fieldset>

--- a/src/routes/lets-work-together/rate.svelte
+++ b/src/routes/lets-work-together/rate.svelte
@@ -2,73 +2,20 @@
 	import { pricing_state } from '$lib/state/pricing-client.svelte'
 	import { number_crunch } from '$lib/utils'
 	import CurrencySelect from './currency-select.svelte'
-	import {
-		calculate_annual_rate_with_pto,
-		calculate_day_rate_with_pto,
-		calculate_monthly_rate_with_pto,
-		locale_string,
-	} from './utils'
+	import { locale_string } from './utils'
 
-	const get_field_value = (field_name: string): number => {
-		return (
-			pricing_state.data.pricingNumbers[
-				field_name as keyof typeof pricing_state.data.pricingNumbers
-			] || 0
-		)
-	}
-
-	let annual_rate_EUR = $state(
-		get_field_value('annual_rate_eur') || 155000,
+	let day_rate_display = $derived(
+		pricing_state.day_rate * pricing_state.currency_rate,
 	)
-	let chosen_holidays = $state(
-		get_field_value('chosen_holidays') || 25,
+	let weekly_display = $derived(
+		pricing_state.weekly_rate * pricing_state.currency_rate,
 	)
-	let working_days_in_year =
-		get_field_value('working_days_in_year') || 260
-	let public_holidays = get_field_value('public_holidays') || 8
-	let selected_currency = $state('EUR')
-
-	let day_rate_with_pto = $derived(
-		calculate_day_rate_with_pto(
-			annual_rate_EUR || 0,
-			working_days_in_year,
-			chosen_holidays,
-			public_holidays,
-		),
+	let monthly_display = $derived(
+		pricing_state.monthly_rate * pricing_state.currency_rate,
 	)
-
-	let monthly_rate_with_pto = $derived(
-		calculate_monthly_rate_with_pto(
-			annual_rate_EUR || 0,
-			working_days_in_year,
-			chosen_holidays,
-			public_holidays,
-		),
+	let annual_display = $derived(
+		pricing_state.annual_rate * pricing_state.currency_rate,
 	)
-
-	let annual_rate_with_pto = $derived(
-		calculate_annual_rate_with_pto(
-			annual_rate_EUR || 0,
-			working_days_in_year,
-			chosen_holidays,
-			public_holidays,
-		),
-	)
-
-	let currency_rate = $derived(
-		selected_currency === 'EUR'
-			? 1
-			: pricing_state.data.exchangeRates[
-					selected_currency as keyof typeof pricing_state.data.exchangeRates
-				],
-	)
-
-	const on_annual_rate_input = (e: Event) => {
-		annual_rate_EUR = Math.max(
-			(e.target as HTMLInputElement).valueAsNumber,
-			get_field_value('annual_rate_eur') || 155000,
-		)
-	}
 </script>
 
 <div class="card bg-base-100 shadow-xl">
@@ -80,32 +27,53 @@
 				<legend class="sr-only">Rate Settings</legend>
 
 				<div class="mb-4">
-					<label for="annual_rate" class="label">
-						<span class="text-base font-medium">
-							Annual rate (EUR): {locale_string(annual_rate_EUR)}
-						</span>
-					</label>
-					<div class="flex items-center gap-4">
-						<input
-							id="annual_rate"
-							type="range"
-							min={155000}
-							max={180000}
-							step={5000}
-							bind:value={annual_rate_EUR}
-							oninput={on_annual_rate_input}
-							class="range range-primary flex-1"
-						/>
-						<span class="badge badge-primary badge-lg">
-							{locale_string(annual_rate_EUR)}
-						</span>
-					</div>
+					<CurrencySelect />
 				</div>
+
+				{#if pricing_state.is_gbp}
+					<div class="mb-4">
+						<label for="ir35_toggle" class="label">
+							<span class="text-base font-medium">
+								IR35 Status:
+							</span>
+						</label>
+						<div class="flex items-center gap-3">
+							<span
+								class="text-sm font-medium"
+								class:text-primary={!pricing_state.ir35_inside}
+							>
+								Outside
+							</span>
+							<input
+								id="ir35_toggle"
+								type="checkbox"
+								bind:checked={pricing_state.ir35_inside}
+								class="toggle toggle-primary"
+							/>
+							<span
+								class="text-sm font-medium"
+								class:text-primary={pricing_state.ir35_inside}
+							>
+								Inside
+							</span>
+						</div>
+						<p class="text-base-content/60 mt-1 text-xs">
+							{#if pricing_state.ir35_inside}
+								Inside IR35: {pricing_state.data.pricing_config
+									.ir35_uplift_pct}% uplift applied to cover
+								employer's NI and tax obligations
+							{:else}
+								Outside IR35: standard contractor rate via limited
+								company
+							{/if}
+						</p>
+					</div>
+				{/if}
 
 				<div class="mb-4">
 					<label for="pto_days" class="label">
 						<span class="text-base font-medium">
-							PTO (days): {chosen_holidays}
+							PTO (days): {pricing_state.pto_days}
 						</span>
 					</label>
 					<div class="flex items-center gap-4">
@@ -115,17 +83,13 @@
 							min={0}
 							max={40}
 							step={1}
-							bind:value={chosen_holidays}
+							bind:value={pricing_state.pto_days}
 							class="range range-primary flex-1"
 						/>
-						<span class="badge badge-primary badge-lg"
-							>{chosen_holidays}</span
-						>
+						<span class="badge badge-primary badge-lg">
+							{pricing_state.pto_days}
+						</span>
 					</div>
-				</div>
-
-				<div class="mb-4">
-					<CurrencySelect bind:selected_currency />
 				</div>
 			</fieldset>
 
@@ -135,12 +99,18 @@
 				<article class="stat">
 					<div class="stat-title font-medium">Day Rate</div>
 					<div class="stat-value text-primary flex items-center">
-						{locale_string(day_rate_with_pto * currency_rate)}
+						{locale_string(day_rate_display)}
 						<span class="ml-2 text-xl">
-							{selected_currency}
+							{pricing_state.selected_currency}
 						</span>
 					</div>
-					<div class="stat-desc"></div>
+					<div class="stat-desc">
+						{#if pricing_state.is_gbp}
+							{pricing_state.ir35_inside
+								? 'Inside IR35'
+								: 'Outside IR35'}
+						{/if}
+					</div>
 				</article>
 
 				<article class="stat">
@@ -148,21 +118,21 @@
 					<div class="stat-value text-secondary">
 						<div
 							class="tooltip flex items-center"
-							data-tip={locale_string(
-								day_rate_with_pto * 5 * currency_rate,
-							)}
+							data-tip={locale_string(weekly_display)}
 						>
-							{number_crunch(day_rate_with_pto * 5 * currency_rate)}
+							{number_crunch(weekly_display)}
 							<span class="ml-2 text-xl">
-								{selected_currency}
+								{pricing_state.selected_currency}
 							</span>
 						</div>
 					</div>
 					<div class="stat-desc">
-						{chosen_holidays === 0
+						{pricing_state.pto_days === 0
 							? `Base rate`
 							: `Incl. ${(
-									(chosen_holidays / working_days_in_year) *
+									(pricing_state.pto_days /
+										pricing_state.data.pricing_config
+											.working_days_in_year) *
 									5
 								).toFixed(2)} days PTO`}
 					</div>
@@ -173,20 +143,18 @@
 					<div class="stat-value text-accent">
 						<div
 							class="tooltip flex items-center"
-							data-tip={locale_string(
-								monthly_rate_with_pto * currency_rate,
-							)}
+							data-tip={locale_string(monthly_display)}
 						>
-							{number_crunch(monthly_rate_with_pto * currency_rate)}
+							{number_crunch(monthly_display)}
 							<span class="ml-2 text-xl">
-								{selected_currency}
+								{pricing_state.selected_currency}
 							</span>
 						</div>
 					</div>
 					<div class="stat-desc">
-						{chosen_holidays === 0
+						{pricing_state.pto_days === 0
 							? `Base rate`
-							: `Incl. ${(chosen_holidays / 12).toFixed(1)} days PTO`}
+							: `Incl. ${(pricing_state.pto_days / 12).toFixed(1)} days PTO`}
 					</div>
 				</article>
 
@@ -195,23 +163,53 @@
 					<div class="stat-value">
 						<div
 							class="tooltip flex items-center"
-							data-tip={locale_string(
-								annual_rate_with_pto * currency_rate,
-							)}
+							data-tip={locale_string(annual_display)}
 						>
-							{number_crunch(annual_rate_with_pto * currency_rate)}
+							{number_crunch(annual_display)}
 							<span class="ml-2 text-xl">
-								{selected_currency}
+								{pricing_state.selected_currency}
 							</span>
 						</div>
 					</div>
 					<div class="stat-desc">
-						{chosen_holidays === 0
+						{pricing_state.pto_days === 0
 							? `Base rate`
-							: `Incl. ${chosen_holidays} days PTO`}
+							: `Incl. ${pricing_state.pto_days} days PTO`}
 					</div>
 				</article>
 			</div>
+
+			{#if pricing_state.is_gbp}
+				<div
+					class="stats stats-vertical border-base-300 bg-base-100 md:stats-horizontal w-full border shadow"
+				>
+					<article class="stat">
+						<div class="stat-title font-medium">
+							Contractor Take-home
+						</div>
+						<div class="stat-value text-primary flex items-center">
+							{number_crunch(pricing_state.contractor_take_home)}
+							<span class="ml-2 text-xl">GBP</span>
+						</div>
+						<div class="stat-desc">
+							Via Ltd company (salary + dividends)
+						</div>
+					</article>
+
+					<article class="stat">
+						<div class="stat-title font-medium">
+							Equivalent Salary
+						</div>
+						<div class="stat-value text-secondary flex items-center">
+							{number_crunch(pricing_state.salary_equivalent)}
+							<span class="ml-2 text-xl">GBP</span>
+						</div>
+						<div class="stat-desc">
+							Permanent salary for same take-home
+						</div>
+					</article>
+				</div>
+			{/if}
 		</div>
 	</div>
 </div>

--- a/src/routes/lets-work-together/utils.test.ts
+++ b/src/routes/lets-work-together/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { billable_days, country_to_currency } from './utils'
+
+describe('country_to_currency', () => {
+	it('returns GBP for GB', () => {
+		expect(country_to_currency('GB')).toBe('GBP')
+	})
+
+	it('returns EUR for eurozone countries', () => {
+		expect(country_to_currency('DE')).toBe('EUR')
+		expect(country_to_currency('FR')).toBe('EUR')
+		expect(country_to_currency('NL')).toBe('EUR')
+		expect(country_to_currency('IE')).toBe('EUR')
+	})
+
+	it('returns USD for US', () => {
+		expect(country_to_currency('US')).toBe('USD')
+	})
+
+	it('returns USD for unknown countries', () => {
+		expect(country_to_currency('JP')).toBe('USD')
+		expect(country_to_currency('AU')).toBe('USD')
+	})
+
+	it('returns USD for null', () => {
+		expect(country_to_currency(null)).toBe('USD')
+	})
+})
+
+describe('billable_days', () => {
+	it('subtracts PTO and public holidays', () => {
+		expect(billable_days(252, 30, 8)).toBe(214)
+	})
+
+	it('defaults to zero PTO and holidays', () => {
+		expect(billable_days(252)).toBe(252)
+	})
+})

--- a/src/routes/lets-work-together/utils.ts
+++ b/src/routes/lets-work-together/utils.ts
@@ -9,47 +9,34 @@ export const billable_days = (
 	public_holidays: number = 0,
 ) => working_days_in_year - (pto_days + public_holidays)
 
-export const calculate_day_rate_with_pto = (
-	annual_rate: number,
-	working_days_in_year: number,
-	pto_days: number = 0,
-	public_holidays: number = 0,
-) => {
-	const total_billable_days = billable_days(
-		working_days_in_year,
-		pto_days,
-		public_holidays,
-	)
-	return annual_rate / total_billable_days
-}
+const EUROZONE_COUNTRIES = new Set([
+	'AT',
+	'BE',
+	'CY',
+	'DE',
+	'EE',
+	'ES',
+	'FI',
+	'FR',
+	'GR',
+	'HR',
+	'IE',
+	'IT',
+	'LT',
+	'LU',
+	'LV',
+	'MT',
+	'NL',
+	'PT',
+	'SI',
+	'SK',
+])
 
-export const calculate_annual_rate_with_pto = (
-	annual_rate: number,
-	working_days_in_year: number,
-	pto_days: number,
-	public_holidays: number = 0,
-) => {
-	const day_rate = calculate_day_rate_with_pto(
-		annual_rate,
-		working_days_in_year,
-		pto_days,
-		public_holidays,
-	)
-	const total_working_days_with_pto = working_days_in_year + pto_days
-	return day_rate * total_working_days_with_pto
-}
-
-export const calculate_monthly_rate_with_pto = (
-	annual_rate: number,
-	working_days_in_year: number,
-	pto_days: number,
-	public_holidays: number = 0,
-) => {
-	const annual = calculate_annual_rate_with_pto(
-		annual_rate,
-		working_days_in_year,
-		pto_days,
-		public_holidays,
-	)
-	return annual / 12
+export const country_to_currency = (
+	country: string | null,
+): string => {
+	if (!country) return 'USD'
+	if (country === 'GB') return 'GBP'
+	if (EUROZONE_COUNTRIES.has(country)) return 'EUR'
+	return 'USD'
 }

--- a/src/routes/lets-work-together/video.svelte
+++ b/src/routes/lets-work-together/video.svelte
@@ -1,91 +1,44 @@
 <script lang="ts">
 	import { pricing_state } from '$lib/state/pricing-client.svelte'
-	import CurrencySelect from './currency-select.svelte'
 	import Select from './select.svelte'
-	import { calculate_day_rate_with_pto, locale_string } from './utils'
-
-	const get_field_value = (field_name: string): number => {
-		return (
-			pricing_state.data.pricingNumbers[
-				field_name as keyof typeof pricing_state.data.pricingNumbers
-			] || 0
-		)
-	}
-
-	let annual_rate_EUR = get_field_value('annual_rate_eur') || 120000
-	let working_days_in_year =
-		get_field_value('working_days_in_year') || 260
-
-	const calculate_cost_with_customisation = (
-		base_cost: number,
-		customisation_percentage: number,
-	) => base_cost * (1 + customisation_percentage)
-
-	const calculate_cost = (multiplier: number) =>
-		calculate_day_rate_with_pto(
-			annual_rate_EUR,
-			working_days_in_year,
-		) * multiplier
+	import { locale_string } from './utils'
 
 	const VIDEO_DURATION = {
-		Short: { description: '5-10 min', cost: calculate_cost(1.5) },
-		Medium: { description: '10-20 min', cost: calculate_cost(2.5) },
-		Long: { description: '20-30 min', cost: calculate_cost(3.6) },
-		'Extra Long': {
-			description: '>30 min',
-			cost: calculate_cost(4.8),
-		},
+		Short: { description: '5-10 min', multiplier: 1.5 },
+		Medium: { description: '10-20 min', multiplier: 2.5 },
+		Long: { description: '20-30 min', multiplier: 3.6 },
+		'Extra Long': { description: '>30 min', multiplier: 4.8 },
 	}
 
-	const VIDEO_CUSTOMISATION_PERCENTAGES = {
+	const VIDEO_CUSTOMISATION = {
 		None: 0,
-		Minor: 0.3, // 30% extra
-		Moderate: 0.5, // 50% extra
-		Major: 1.1, // 110% extra
+		Minor: 0.3,
+		Moderate: 0.5,
+		Major: 1.1,
 	}
 
-	const VIDEO_DURATION_OPTIONS = Object.keys(VIDEO_DURATION)
-	const CUSTOMISATION_LEVEL_OPTIONS = Object.keys(
-		VIDEO_CUSTOMISATION_PERCENTAGES,
+	let selected_video_duration = $state(Object.keys(VIDEO_DURATION)[0])
+	let selected_customisation = $state(
+		Object.keys(VIDEO_CUSTOMISATION)[0],
 	)
 
-	let selected_video_duration = $state(VIDEO_DURATION_OPTIONS[0])
-	let selected_customisation_level = $state(
-		CUSTOMISATION_LEVEL_OPTIONS[0],
-	)
-	let selected_currency = $state('EUR')
-	let selected_duration: string | undefined = $state()
-
-	$effect.pre(() => {
-		selected_duration =
-			VIDEO_DURATION[
-				selected_video_duration as keyof typeof VIDEO_DURATION
-			].description
-	})
-	let video_cost = $derived(
+	let duration_config = $derived(
 		VIDEO_DURATION[
 			selected_video_duration as keyof typeof VIDEO_DURATION
-		].cost,
-	)
-	let video_cost_with_customisation = $derived(
-		calculate_cost_with_customisation(
-			video_cost,
-			VIDEO_CUSTOMISATION_PERCENTAGES[
-				selected_customisation_level as keyof typeof VIDEO_CUSTOMISATION_PERCENTAGES
-			],
-		),
+		],
 	)
 
-	let currency_rate = $derived(
-		selected_currency === 'EUR'
-			? 1
-			: pricing_state.data.exchangeRates[
-					selected_currency as keyof typeof pricing_state.data.exchangeRates
-				],
+	let customisation_pct = $derived(
+		VIDEO_CUSTOMISATION[
+			selected_customisation as keyof typeof VIDEO_CUSTOMISATION
+		],
 	)
 
-	let video_cost_with_customisation_in_selected_currency = $derived(
-		video_cost_with_customisation * currency_rate,
+	let total_cost = $derived(
+		pricing_state.day_rate *
+			duration_config.multiplier *
+			(1 + customisation_pct) *
+			pricing_state.currency_rate,
 	)
 </script>
 
@@ -104,7 +57,7 @@
 						id="duration"
 						label="Video duration:"
 						bind:selected={selected_video_duration}
-						options={VIDEO_DURATION_OPTIONS}
+						options={Object.keys(VIDEO_DURATION)}
 					/>
 				</div>
 
@@ -112,13 +65,9 @@
 					<Select
 						id="customisation_level"
 						label="Customisation level:"
-						bind:selected={selected_customisation_level}
-						options={CUSTOMISATION_LEVEL_OPTIONS}
+						bind:selected={selected_customisation}
+						options={Object.keys(VIDEO_CUSTOMISATION)}
 					/>
-				</div>
-
-				<div class="mb-4">
-					<CurrencySelect bind:selected_currency />
 				</div>
 			</fieldset>
 
@@ -128,7 +77,7 @@
 				<div class="stat">
 					<div class="stat-title font-medium">Length</div>
 					<div class="stat-value text-primary flex items-center">
-						{selected_duration}
+						{duration_config.description}
 					</div>
 					<div class="stat-desc">Video duration</div>
 				</div>
@@ -136,14 +85,14 @@
 				<div class="stat">
 					<div class="stat-title font-medium">Customisation</div>
 					<div class="stat-value text-secondary flex items-center">
-						{selected_customisation_level}
+						{selected_customisation}
 					</div>
 					<div class="stat-desc">
-						{#if selected_customisation_level === 'None'}
+						{#if selected_customisation === 'None'}
 							Standard format
-						{:else if selected_customisation_level === 'Minor'}
+						{:else if selected_customisation === 'Minor'}
 							Light customisation (+30%)
-						{:else if selected_customisation_level === 'Moderate'}
+						{:else if selected_customisation === 'Moderate'}
 							Medium customisation (+50%)
 						{:else}
 							Heavy customisation (+110%)
@@ -154,11 +103,9 @@
 				<div class="stat">
 					<div class="stat-title font-medium">Total</div>
 					<div class="stat-value text-accent flex items-center">
-						{locale_string(
-							video_cost_with_customisation_in_selected_currency,
-						)}
+						{locale_string(total_cost)}
 						<span class="ml-2 text-xl">
-							{selected_currency}
+							{pricing_state.selected_currency}
 						</span>
 					</div>
 					<div class="stat-desc">Final price</div>

--- a/src/routes/lets-work-together/workshop.svelte
+++ b/src/routes/lets-work-together/workshop.svelte
@@ -1,22 +1,9 @@
 <script lang="ts">
 	import { pricing_state } from '$lib/state/pricing-client.svelte'
-	import CurrencySelect from './currency-select.svelte'
 	import Select from './select.svelte'
 	import { locale_string } from './utils'
 
-	const get_field_value = (field_name: string): number => {
-		return (pricing_state.data.pricingNumbers as any)[field_name] || 0
-	}
-
-	let annual_rate_EUR = get_field_value('annual_rate_eur') || 120000
-	let working_days_in_year =
-		get_field_value('working_days_in_year') || 260
-
-	let attendees = $state(5) // Minimum number of attendees
-	let selected_currency = $state('EUR')
-	let workshop_duration = $state('90 minutes')
-
-	const BESPOKE_PERCENTAGES: Record<string, number> = {
+	const WORKSHOP_DURATION: Record<string, number> = {
 		'90 minutes': 1.2,
 		'Half day': 1.8,
 		'Full day': 3.5,
@@ -24,47 +11,24 @@
 		'Three days': 9,
 	}
 
-	const calculate_day_rate = (
-		annual_rate: number,
-		working_days: number,
-	) => {
-		return annual_rate / working_days
-	}
+	let attendees = $state(5)
+	let workshop_duration = $state('90 minutes')
 
-	const calculate_workshop_cost = (
-		annual_rate: number,
-		working_days: number,
-		attendees: number,
-		workshop_duration: string,
-	) => {
-		let base_cost = calculate_day_rate(annual_rate, working_days)
-		let discount_factor = 1 - Math.log(attendees) / 20
+	let workshop_cost = $derived.by(() => {
+		const base = pricing_state.day_rate
+		const discount_factor = 1 - Math.log(attendees) / 20
 		return (
-			base_cost *
+			base *
 			discount_factor *
 			attendees *
-			BESPOKE_PERCENTAGES[workshop_duration]
+			WORKSHOP_DURATION[workshop_duration]
 		)
-	}
+	})
 
-	let workshop_cost_EUR = $derived(
-		calculate_workshop_cost(
-			annual_rate_EUR,
-			working_days_in_year,
-			attendees,
-			workshop_duration,
-		),
+	let total_display = $derived(
+		workshop_cost * pricing_state.currency_rate,
 	)
-	let currency_rate = $derived(
-		selected_currency === 'EUR'
-			? 1
-			: pricing_state.data.exchangeRates[
-					selected_currency as keyof typeof pricing_state.data.exchangeRates
-				],
-	)
-	let price_per_attendee = $derived(
-		(workshop_cost_EUR * currency_rate) / attendees,
-	)
+	let per_attendee_display = $derived(total_display / attendees)
 
 	const on_attendees_input = (e: Event) => {
 		attendees = Math.max(
@@ -87,7 +51,7 @@
 						id="workshop_duration"
 						label="Workshop Duration:"
 						bind:selected={workshop_duration}
-						options={Object.keys(BESPOKE_PERCENTAGES)}
+						options={Object.keys(WORKSHOP_DURATION)}
 					/>
 				</div>
 
@@ -112,10 +76,6 @@
 						</span>
 					</div>
 				</div>
-
-				<div class="mb-4">
-					<CurrencySelect bind:selected_currency />
-				</div>
 			</fieldset>
 
 			<div
@@ -133,9 +93,9 @@
 				<div class="stat">
 					<div class="stat-title font-medium">Price Per Attendee</div>
 					<div class="stat-value text-secondary flex items-center">
-						{locale_string(price_per_attendee)}
+						{locale_string(per_attendee_display)}
 						<span class="ml-2 text-xl">
-							{selected_currency}
+							{pricing_state.selected_currency}
 						</span>
 					</div>
 					<div class="stat-desc">Cost per person</div>
@@ -144,9 +104,9 @@
 				<div class="stat">
 					<div class="stat-title font-medium">Workshop Cost</div>
 					<div class="stat-value text-accent flex items-center">
-						{locale_string(workshop_cost_EUR * currency_rate)}
+						{locale_string(total_display)}
 						<span class="ml-2 text-xl">
-							{selected_currency}
+							{pricing_state.selected_currency}
 						</span>
 					</div>
 					<div class="stat-desc">Total workshop price</div>
@@ -166,10 +126,10 @@
 						d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
 					></path></svg
 				>
-				<span
-					>Group discounts are automatically applied as the number of
-					attendees increases.</span
-				>
+				<span>
+					Group discounts are automatically applied as the number of
+					attendees increases.
+				</span>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

- Replace EUR annual rate with GBP day rate (£575) as single source of truth for all pricing calculators
- Add UK tax calculator that derives contractor take-home (£87.8k) and equivalent permanent salary (£138.7k) from HMRC tax bands stored in DB
- Auto-detect visitor currency from Cloudflare cf-ipcountry header (GB→GBP, eurozone→EUR, everyone else→USD)
- IR35 inside/outside toggle only shown when GBP is selected
- All four calculators (rate, blog post, video, workshop) now share global currency selection and derive costs reactively from the day rate

## Changes

- **DB**: New `pricing_config` and `uk_tax_config` tables (migrations 012, 013)
- **Server**: Exchange rates now fetched with GBP base, tax config loaded from DB
- **Client**: Centralised `PricingState` singleton with reactive getters for day rate, currency conversion, tax comparison
- **Components**: Removed per-calculator currency selectors and stale fallbacks; all derive from shared state
- **Tax**: `uk-tax-calculator.ts` with full PAYE + NI + Ltd company (corp tax + dividends) calculations

## Test plan

- [ ] Visit /lets-work-together — should default to USD (no cf-ipcountry locally)
- [ ] Switch to GBP — IR35 toggle and salary equivalent section appear
- [ ] Toggle IR35 inside — day rate should show £719 (25% uplift)
- [ ] Adjust PTO slider — weekly/monthly/annual rates update across all widgets
- [ ] Switch currencies — all four calculators update simultaneously
- [ ] Blog post short/overview = 1× day rate, medium = 2×, etc.
- [ ] Verify tax numbers: contractor take-home ~£87.8k, equivalent salary ~£138.7k