### PR TITLE
Replace better-sqlite3 with node:sqlite

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,10 +1,10 @@
 [phases.setup]
-nixPkgs = ["nodejs_24", "sqlite", "gcc", "pkg-config"]
-aptPkgs = ["curl", "wget", "libsqlite3-dev", "sqlite3"]
+nixPkgs = ["nodejs_24"]
+aptPkgs = ["curl", "wget"]
 
 [phases.install]
 cmds = [
-  "npm install -g pnpm@11.9.0 && $(npm prefix -g)/bin/pnpm install --frozen-lockfile --config.engine-strict=false --config.optional=true"
+	"npm install -g pnpm@11.9.0 && $(npm prefix -g)/bin/pnpm install --frozen-lockfile --config.engine-strict=false --config.optional=true",
 ]
 
 [phases.build]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"packageManager": "pnpm@11.20.0",
 	"engines": {
-		"node": ">=24.0.0",
+		"node": ">=24.15.0",
 		"pnpm": ">=11.0.0"
 	},
 	"author": {
@@ -43,7 +43,6 @@
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
 		"@tailwindcss/typography": "0.5.20",
 		"@tailwindcss/vite": "^4.3.1",
-		"@types/better-sqlite3": "^7.6.13",
 		"@types/d3-scale": "^4.0.9",
 		"@types/node": "^26.0.1",
 		"@upstash/ratelimit": "^2.0.8",
@@ -83,7 +82,6 @@
 	"dependencies": {
 		"@octokit/rest": "^22.0.1",
 		"@types/d3-shape": "^3.1.8",
-		"better-sqlite3": "^12.11.1",
 		"d3-shape": "^3.2.0",
 		"sqlite-vec": "0.1.9"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@types/d3-shape':
         specifier: ^3.1.8
         version: 3.1.8
-      better-sqlite3:
-        specifier: ^12.11.1
-        version: 12.11.1
       d3-shape:
         specifier: ^3.2.0
         version: 3.2.0
@@ -51,9 +48,6 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.3(vite@8.1.5(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
       '@types/d3-scale':
         specifier: ^4.0.9
         version: 4.0.9
@@ -1289,9 +1283,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
-
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1773,27 +1764,11 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
-  better-sqlite3@12.11.1:
-    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
-
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1826,9 +1801,6 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2105,14 +2077,6 @@ packages:
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -2155,9 +2119,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.24.2:
     resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
@@ -2207,10 +2168,6 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -2240,14 +2197,8 @@ packages:
       picomatch:
         optional: true
 
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2265,9 +2216,6 @@ packages:
   gensequence@8.0.8:
     resolution: {integrity: sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg==}
     engines: {node: '>=20'}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -2329,21 +2277,12 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   import-fresh@4.0.0:
     resolution: {integrity: sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==}
     engines: {node: '>=22.15'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
@@ -2613,16 +2552,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -2636,22 +2565,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
-  node-abi@3.92.0:
-    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
-    engines: {node: '>=10'}
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   oxfmt@0.60.0:
     resolution: {integrity: sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==}
@@ -2742,12 +2661,6 @@ packages:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2762,19 +2675,8 @@ packages:
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
-
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2845,9 +2747,6 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2870,12 +2769,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -2933,15 +2826,8 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
@@ -2988,13 +2874,6 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.5:
-    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3030,9 +2909,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turnstile-types@1.2.3:
     resolution: {integrity: sha512-EDjhDB9TDwda2JRbhzO/kButPio3JgrC3gXMVAMotxldybTCJQVMvPNJ89rcAiN9vIrCb2i1E+VNBCqB8wue0A==}
@@ -3262,9 +3138,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -4173,10 +4046,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/better-sqlite3@7.6.13':
-    dependencies:
-      '@types/node': 26.1.2
-
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4573,31 +4442,9 @@ snapshots:
 
   bail@2.0.2: {}
 
-  base64-js@1.5.1: {}
-
   before-after-hook@4.0.0: {}
 
-  better-sqlite3@12.11.1:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   boolbase@1.0.0: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   ccount@2.0.1: {}
 
@@ -4635,8 +4482,6 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
-
-  chownr@1.1.4: {}
 
   clsx@2.1.1: {}
 
@@ -4977,12 +4822,6 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
-  deep-extend@0.6.0: {}
-
   deepmerge@4.3.1: {}
 
   delaunator@5.1.0:
@@ -5025,10 +4864,6 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
   enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -5062,8 +4897,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
-  expand-template@2.0.3: {}
-
   expect-type@1.4.0: {}
 
   extend@3.0.2: {}
@@ -5080,11 +4913,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  file-uri-to-path@1.0.0: {}
-
   flatted@3.4.2: {}
-
-  fs-constants@1.0.0: {}
 
   fsevents@2.3.2:
     optional: true
@@ -5095,8 +4924,6 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensequence@8.0.8: {}
-
-  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -5202,15 +5029,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
-
   import-fresh@4.0.0: {}
 
   import-meta-resolve@4.2.0: {}
-
-  inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   ini@6.0.0: {}
 
@@ -5466,33 +5287,17 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
-
-  minimist@1.2.8: {}
-
-  mkdirp-classic@0.5.3: {}
-
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
 
   nanoid@3.3.16: {}
 
-  napi-build-utils@2.0.0: {}
-
-  node-abi@3.92.0:
-    dependencies:
-      semver: 7.8.5
-
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
 
   obug@2.1.3: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   oxfmt@0.60.0(svelte@5.56.8)(vite-plus@0.2.7(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(jiti@2.7.0)(svelte@5.56.8)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
@@ -5606,21 +5411,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.92.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.5
-      tunnel-agent: 0.6.0
-
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5633,25 +5423,7 @@ snapshots:
 
   property-information@6.5.0: {}
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
-
   react-is@17.0.2: {}
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -5780,8 +5552,6 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
-  safe-buffer@5.2.1: {}
-
   safer-buffer@2.1.2: {}
 
   schema-dts-lib@1.0.0(typescript@6.0.3):
@@ -5799,14 +5569,6 @@ snapshots:
   set-cookie-parser@3.1.2: {}
 
   siginfo@2.0.0: {}
-
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
 
   sirv@3.0.2:
     dependencies:
@@ -5854,16 +5616,10 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
-
-  strip-json-comments@2.0.1: {}
 
   stylis@4.4.0: {}
 
@@ -5925,21 +5681,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar-fs@2.1.5:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -5965,10 +5706,6 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   turnstile-types@1.2.3: {}
 
@@ -6227,8 +5964,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrappy@1.0.2: {}
 
   ws@8.21.0: {}
 

--- a/src/lib/sqlite/client.ts
+++ b/src/lib/sqlite/client.ts
@@ -1,12 +1,12 @@
-import { DATABASE_PATH } from '$env/static/private'
-import type { RunResult } from 'better-sqlite3'
-import Database from 'better-sqlite3'
-import fs from 'node:fs'
-import path from 'node:path'
-import * as sqliteVec from 'sqlite-vec'
+import { DATABASE_PATH } from '$env/static/private';
+import { DatabaseSync } from 'node:sqlite';
+import type { SQLInputValue } from 'node:sqlite';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as sqliteVec from 'sqlite-vec';
 
 // Global database instance for singleton pattern with lazy initialization
-let db_instance: Database.Database | null = null
+let db_instance: DatabaseSync | null = null;
 
 /**
  * Creates and configures a new SQLite database instance
@@ -25,60 +25,65 @@ const create_database = () => {
 	// Database path configuration
 	// Priority: Environment variable > Default data directory
 	const db_path =
-		DATABASE_PATH || path.join(process.cwd(), 'data', 'site-data.db')
+		DATABASE_PATH || path.join(process.cwd(), 'data', 'site-data.db');
 
 	// Ensure directory exists (critical for first deployment)
-	const db_dir = path.dirname(db_path)
+	const db_dir = path.dirname(db_path);
 	if (!fs.existsSync(db_dir)) {
-		fs.mkdirSync(db_dir, { recursive: true })
+		fs.mkdirSync(db_dir, { recursive: true });
 	}
 
-	const db = new Database(db_path)
+	const db = new DatabaseSync(db_path, {
+		allowExtension: true,
+		timeout: 5000,
+	});
 
 	/**
 	 * Load sqlite-vec extension for vector similarity search
 	 *
 	 * DOCKER/COOLIFY DEPLOYMENT:
 	 * - Uses the sqlite-vec npm package for reliable cross-platform support
-	 * - Requires system packages: libsqlite3-dev, sqlite3 (configured in nixpacks.toml)
 	 * - Gracefully degrades if extension loading fails
 	 */
 	const load_vec_extension = () => {
 		try {
-			sqliteVec.load(db)
-			console.log('sqlite-vec extension loaded successfully')
+			db.loadExtension(sqliteVec.getLoadablePath());
+			console.log('sqlite-vec extension loaded successfully');
 		} catch (error) {
-			console.warn('sqlite-vec extension failed to load:', error)
-			console.warn('Vector similarity queries will not work')
+			console.warn('sqlite-vec extension failed to load:', error);
+			console.warn('Vector similarity queries will not work');
+		} finally {
+			db.enableLoadExtension(false);
 		}
-	}
+	};
 
-	load_vec_extension()
+	load_vec_extension();
 
 	// Enable WAL mode for better concurrent access
-	db.pragma('journal_mode = WAL')
-	// Wait up to 5s on lock contention instead of failing instantly
-	db.pragma('busy_timeout = 5000')
+	db.exec('PRAGMA journal_mode = WAL');
 
-	return db
-}
+	return db;
+};
 
 // Type definition for the SQLite client
 export type SqliteClient = {
 	execute: (query: string | { sql: string; args?: unknown[] }) => {
-		rows: Record<string, unknown>[]
-	}
+		rows: Record<string, unknown>[];
+	};
 	batch: (queries: { sql: string; args?: unknown[] }[]) => {
-		success: boolean
-	}
+		success: boolean;
+	};
 	prepare: (query: string) => {
-		run: (...args: unknown[]) => RunResult
-		get: (...args: unknown[]) => Record<string, unknown> | undefined
-		all: (...args: unknown[]) => Record<string, unknown>[]
-	}
-	exec: (sql: string) => void
-	close: () => void
-}
+		run: (...args: unknown[]) => {
+			changes: number;
+			lastInsertRowid: number | bigint;
+		};
+		get: (...args: unknown[]) => Record<string, unknown> | undefined;
+		all: (...args: unknown[]) => Record<string, unknown>[];
+	};
+	exec: (sql: string) => void;
+	close: () => void;
+};
 
 /**
  * Lazy database initialization - creates database instance only when first accessed
@@ -89,14 +94,14 @@ export type SqliteClient = {
 const get_database = () => {
 	if (!db_instance) {
 		try {
-			db_instance = create_database()
+			db_instance = create_database();
 		} catch (error) {
-			console.error('Failed to initialize database:', error)
-			throw error
+			console.error('Failed to initialize database:', error);
+			throw error;
 		}
 	}
-	return db_instance
-}
+	return db_instance;
+};
 
 /**
  * SQLite client with libsql-compatible API
@@ -112,108 +117,120 @@ const get_database = () => {
 export const sqlite_client: SqliteClient = {
 	execute: (query: string | { sql: string; args?: unknown[] }) => {
 		if (!query) {
-			throw new Error('Query cannot be empty')
+			throw new Error('Query cannot be empty');
 		}
 
 		try {
-			const db = get_database()
+			const db = get_database();
 			if (typeof query === 'string') {
 				// Simple string query
-				const stmt = db.prepare(query)
-				const rows = stmt.all() as Record<string, unknown>[]
-				return { rows }
+				const stmt = db.prepare(query);
+				const rows = stmt.all() as Record<string, unknown>[];
+				return { rows };
 			} else {
 				// Query with parameters
 				if (!query.sql) {
-					throw new Error('SQL string is required')
+					throw new Error('SQL string is required');
 				}
-				const stmt = db.prepare(query.sql)
+				const stmt = db.prepare(query.sql);
 				const rows = (
-					query.args ? stmt.all(...query.args) : stmt.all()
-				) as Record<string, unknown>[]
-				return { rows }
+					query.args
+						? stmt.all(...(query.args as SQLInputValue[]))
+						: stmt.all()
+				) as Record<string, unknown>[];
+				return { rows };
 			}
 		} catch (error) {
-			console.error('SQLite execute error:', error)
-			throw error
+			console.error('SQLite execute error:', error);
+			throw error;
 		}
 	},
 
 	batch: (queries: { sql: string; args?: unknown[] }[]) => {
 		if (!queries || queries.length === 0) {
-			throw new Error('Queries array cannot be empty')
+			throw new Error('Queries array cannot be empty');
 		}
 
+		const db = get_database();
 		try {
-			const db = get_database()
-			const transaction = db.transaction(() => {
-				for (const query of queries) {
-					if (!query.sql) {
-						throw new Error('SQL string is required for batch query')
-					}
-					const stmt = db.prepare(query.sql)
-					if (query.args) {
-						stmt.run(...query.args)
-					} else {
-						stmt.run()
-					}
+			db.exec('BEGIN');
+			for (const query of queries) {
+				if (!query.sql) {
+					throw new Error('SQL string is required for batch query');
 				}
-			})
-			transaction()
-			return { success: true }
+				const stmt = db.prepare(query.sql);
+				if (query.args) {
+					stmt.run(...(query.args as SQLInputValue[]));
+				} else {
+					stmt.run();
+				}
+			}
+			db.exec('COMMIT');
+			return { success: true };
 		} catch (error) {
-			console.error('SQLite batch error:', error)
-			throw error
+			if (db.isTransaction) {
+				db.exec('ROLLBACK');
+			}
+			console.error('SQLite batch error:', error);
+			throw error;
 		}
 	},
 
 	prepare: (query: string) => {
 		if (!query) {
-			throw new Error('Query cannot be empty')
+			throw new Error('Query cannot be empty');
 		}
 
-		const db = get_database()
-		const stmt = db.prepare(query)
+		const db = get_database();
+		const stmt = db.prepare(query);
 		return {
-			run: (...args: unknown[]) => stmt.run(...args),
+			run: (...args: unknown[]) => {
+				const result = stmt.run(...(args as SQLInputValue[]));
+				return { ...result, changes: Number(result.changes) };
+			},
 			get: (...args: unknown[]) =>
-				stmt.get(...args) as Record<string, unknown> | undefined,
+				stmt.get(...(args as SQLInputValue[])) as
+					| Record<string, unknown>
+					| undefined,
 			all: (...args: unknown[]) =>
-				stmt.all(...args) as Record<string, unknown>[],
-		}
+				stmt.all(...(args as SQLInputValue[])) as Record<
+					string,
+					unknown
+				>[],
+		};
 	},
 
 	exec: (sql: string) => {
 		if (!sql) {
-			throw new Error('SQL cannot be empty')
+			throw new Error('SQL cannot be empty');
 		}
 
 		try {
-			const db = get_database()
-			db.exec(sql)
+			const db = get_database();
+			db.exec(sql);
 		} catch (error) {
-			console.error('SQLite exec error:', error)
-			throw error
+			console.error('SQLite exec error:', error);
+			throw error;
 		}
 	},
 
 	close: () => {
 		if (db_instance) {
 			try {
-				db_instance.close()
-				db_instance = null
-				console.log('Database connection closed')
+				db_instance.close();
+				db_instance = null;
+				console.log('Database connection closed');
 			} catch (error) {
-				console.error('Error closing database:', error)
+				console.error('Error closing database:', error);
 			}
 		}
 	},
-}
+};
 
 /**
  * No-op sync function for local SQLite (no replication needed)
  * Maintains API compatibility with Turso's sync_replica function
  */
 export const sync_sqlite_replica = async (): Promise<void> => {
-	console.log('Local SQLite: no sync needed')
-}
+	console.log('Local SQLite: no sync needed');
+};

--- a/src/lib/sqlite/node-sqlite-migration.test.ts
+++ b/src/lib/sqlite/node-sqlite-migration.test.ts
@@ -1,0 +1,82 @@
+import { backup, DatabaseSync } from 'node:sqlite';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import * as sqliteVec from 'sqlite-vec';
+import { describe, expect, test } from 'vitest';
+import package_json from '../../../package.json' with { type: 'json' };
+
+const project_root = path.resolve(import.meta.dirname, '../../..');
+
+describe('node:sqlite migration', () => {
+	test('requires a Coolify-compatible Node runtime with node:sqlite', () => {
+		expect(package_json.engines.node).toBe('>=24.15.0');
+		expect(DatabaseSync).toBeTypeOf('function');
+	});
+
+	test('does not depend on better-sqlite3 packages', () => {
+		expect(package_json.dependencies).not.toHaveProperty(
+			'better-sqlite3',
+		);
+		expect(package_json.devDependencies).not.toHaveProperty(
+			'@types/better-sqlite3',
+		);
+	});
+
+	test('does not install redundant SQLite build packages in Nixpacks', async () => {
+		const nixpacks = await fs.readFile(
+			path.join(project_root, 'nixpacks.toml'),
+			'utf8',
+		);
+
+		expect(nixpacks).toContain('nodejs_24');
+		expect(nixpacks).not.toContain('libsqlite3-dev');
+		expect(nixpacks).not.toContain('"sqlite"');
+		expect(nixpacks).not.toContain('sqlite3');
+		expect(nixpacks).not.toContain('gcc');
+		expect(nixpacks).not.toContain('pkg-config');
+	});
+
+	test('keeps SQLite backup behaviour through node:sqlite', async () => {
+		const temp_dir = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'node-sqlite-backup-'),
+		);
+		const db_path = path.join(temp_dir, 'source.db');
+		const backup_path = path.join(temp_dir, 'backup.db');
+		const db = new DatabaseSync(db_path);
+
+		try {
+			db.exec('CREATE TABLE entries (value TEXT NOT NULL)');
+			db.prepare('INSERT INTO entries (value) VALUES (?)').run('ok');
+
+			await backup(db, backup_path);
+		} finally {
+			db.close();
+		}
+
+		const restored = new DatabaseSync(backup_path, {
+			readOnly: true,
+		});
+		try {
+			expect(
+				restored.prepare('SELECT value FROM entries').get(),
+			).toEqual({ value: 'ok' });
+		} finally {
+			restored.close();
+			await fs.rm(temp_dir, { recursive: true, force: true });
+		}
+	});
+
+	test('keeps sqlite-vec loadable extension support', () => {
+		const db = new DatabaseSync(':memory:', { allowExtension: true });
+
+		try {
+			sqliteVec.load(db);
+			expect(
+				db.prepare('SELECT vec_version() AS version').get(),
+			).toEqual({ version: 'v0.1.9' });
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/src/routes/api/ingest/backup-database.ts
+++ b/src/routes/api/ingest/backup-database.ts
@@ -1,52 +1,52 @@
-import { DATABASE_PATH } from '$env/static/private'
-import Database from 'better-sqlite3'
-import fs from 'node:fs/promises'
-import path from 'node:path'
+import { DATABASE_PATH } from '$env/static/private';
+import { backup, DatabaseSync } from 'node:sqlite';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 export const backup_database = async () => {
 	try {
 		const db_path =
 			DATABASE_PATH ||
-			path.join(process.cwd(), 'data', 'site-data.db')
-		const backups_dir = path.join(path.dirname(db_path), 'backups')
+			path.join(process.cwd(), 'data', 'site-data.db');
+		const backups_dir = path.join(path.dirname(db_path), 'backups');
 
 		// Ensure backups directory exists
-		await fs.mkdir(backups_dir, { recursive: true })
+		await fs.mkdir(backups_dir, { recursive: true });
 
 		// Create timestamped backup filename with hour for multiple backups per day
-		const now = new Date()
-		const date = now.toISOString().split('T')[0] // YYYY-MM-DD
-		const hour = now.getHours().toString().padStart(2, '0')
-		const backup_filename = `site-data-${date}-${hour}00.db`
-		const backup_path = path.join(backups_dir, backup_filename)
+		const now = new Date();
+		const date = now.toISOString().split('T')[0]; // YYYY-MM-DD
+		const hour = now.getHours().toString().padStart(2, '0');
+		const backup_filename = `site-data-${date}-${hour}00.db`;
+		const backup_path = path.join(backups_dir, backup_filename);
 
 		// Use SQLite's native backup API to avoid corruption with WAL mode
 		// Opens a separate connection for backup to ensure consistency
-		const source_db = new Database(db_path, { readonly: true })
+		const source_db = new DatabaseSync(db_path, { readOnly: true });
 
 		try {
-			await source_db.backup(backup_path)
+			await backup(source_db, backup_path);
 		} finally {
-			source_db.close()
+			source_db.close();
 		}
 
 		// Clean up old backups (keep 28 backups = 7 days × 4 backups/day)
-		const files = await fs.readdir(backups_dir)
+		const files = await fs.readdir(backups_dir);
 		const backup_files = files
 			.filter(
 				(file) =>
 					file.startsWith('site-data-') && file.endsWith('.db'),
 			)
 			.sort()
-			.reverse() // newest first
+			.reverse(); // newest first
 
 		// Remove files beyond the 28 most recent
-		const files_to_delete = backup_files.slice(28)
+		const files_to_delete = backup_files.slice(28);
 		for (const file of files_to_delete) {
-			await fs.unlink(path.join(backups_dir, file))
+			await fs.unlink(path.join(backups_dir, file));
 		}
 
-		const backup_size = await fs.stat(backup_path)
+		const backup_size = await fs.stat(backup_path);
 
 		return {
 			message: 'Database exported successfully',
@@ -54,9 +54,9 @@ export const backup_database = async () => {
 			backup_size: `${Math.round(backup_size.size / 1024 / 1024)}MB`,
 			backups_kept: Math.min(backup_files.length, 28),
 			files_deleted: files_to_delete.length,
-		}
+		};
 	} catch (error) {
-		console.error('Error exporting database:', error)
-		throw error
+		console.error('Error exporting database:', error);
+		throw error;
 	}
-}
+};

--- a/src/routes/api/ingest/embeddings.ts
+++ b/src/routes/api/ingest/embeddings.ts
@@ -1,5 +1,5 @@
-import { VOYAGE_AI_API_KEY } from '$env/static/private'
-import { sqlite_client } from '$lib/sqlite/client'
+import { VOYAGE_AI_API_KEY } from '$env/static/private';
+import { sqlite_client } from '$lib/sqlite/client';
 
 const create_embedding = async (text: string): Promise<number[]> => {
 	try {
@@ -17,35 +17,35 @@ const create_embedding = async (text: string): Promise<number[]> => {
 					input_type: 'document',
 				}),
 			},
-		)
+		);
 		if (!response.ok) {
-			const errorBody = await response.text()
+			const errorBody = await response.text();
 			throw new Error(
 				`HTTP error! status: ${response.status}, body: ${errorBody}`,
-			)
+			);
 		}
-		const data = await response.json()
+		const data = await response.json();
 		if (!data.data || !data.data[0] || !data.data[0].embedding) {
-			throw new Error('Unexpected API response format')
+			throw new Error('Unexpected API response format');
 		}
-		return data.data[0].embedding
+		return data.data[0].embedding;
 	} catch (error) {
-		console.error('Error creating embedding:', error)
-		throw error
+		console.error('Error creating embedding:', error);
+		throw error;
 	}
-}
+};
 
 export const store_post_embedding = async (
 	post_id: string,
 	content: string,
 ) => {
-	const client = sqlite_client
+	const client = sqlite_client;
 	try {
-		const embedding = await create_embedding(content)
+		const embedding = await create_embedding(content);
 		if (embedding.length !== 1024) {
 			throw new Error(
 				`Expected 1024 dimensions, but got ${embedding.length}`,
-			)
+			);
 		}
 
 		// For sqlite-vec, we can either:
@@ -53,44 +53,42 @@ export const store_post_embedding = async (
 		// 2. Use Float32Array buffer with vec_f32() function
 
 		// Option 1: JSON format (recommended for new embeddings)
-		const embedding_json = JSON.stringify(embedding)
+		const embedding_json = JSON.stringify(embedding);
 
 		const stmt = client.prepare(`
-			INSERT OR REPLACE INTO post_embeddings (post_id, embedding) 
+			INSERT OR REPLACE INTO post_embeddings (post_id, embedding)
 			VALUES (?, ?)
-		`)
-		stmt.run(post_id, embedding_json)
-
-		client.close()
+		`);
+		stmt.run(post_id, embedding_json);
 	} catch (error) {
 		console.error(
 			`Error storing embedding for post ${post_id}:`,
 			error,
-		)
-		throw error
+		);
+		throw error;
 	}
-}
+};
 
 export const get_related_posts = async (
 	post_id: string,
 	limit: number = 12,
 ) => {
-	const client = sqlite_client
+	const client = sqlite_client;
 	try {
 		// Check if the current post has an embedding first
 		const check_stmt = client.prepare(`
 			SELECT post_id FROM post_embeddings WHERE post_id = ?
-		`)
-		const has_embedding = check_stmt.get(post_id)
+		`);
+		const has_embedding = check_stmt.get(post_id);
 
 		if (!has_embedding) {
 			// No embedding for this post yet, return empty array
-			return []
+			return [];
 		}
 
 		// Use a higher k value to account for private posts being filtered out
 		// Multiply by 3 to ensure we get enough public posts after filtering
-		const search_limit = limit * 3
+		const search_limit = limit * 3;
 
 		// Option 1: Use KNN syntax with higher k, then filter for privacy
 		const stmt = client.prepare(`
@@ -103,89 +101,93 @@ export const get_related_posts = async (
 			AND k = ?
 			AND pe.post_id != ?
 			AND p.is_private = 0
-		`)
+		`);
 
-		const results = stmt.all(post_id, search_limit, post_id)
+		const results = stmt.all(post_id, search_limit, post_id);
 
 		// Filter out the original post if it appears and limit results
 		return results
 			.filter((row: any) => row.post_id !== post_id)
 			.slice(0, limit)
-			.map((row: any) => row.post_id)
+			.map((row: any) => row.post_id);
 	} catch (error) {
-		console.error('Error getting related posts:', error)
+		console.error('Error getting related posts:', error);
 
 		// Fallback to traditional distance calculation with private post filtering
 		try {
 			const stmt = client.prepare(`
-				SELECT pe.post_id, 
+				SELECT pe.post_id,
 					vec_distance_cosine(
-						pe.embedding, 
+						pe.embedding,
 						(SELECT embedding FROM post_embeddings WHERE post_id = ?)
-					) as distance 
+					) as distance
 				FROM post_embeddings pe
 				JOIN posts p ON pe.post_id = p.slug
 				WHERE pe.post_id != ?
 				AND p.is_private = 0
-				ORDER BY distance ASC 
+				ORDER BY distance ASC
 				LIMIT ?
-			`)
+			`);
 
-			const results = stmt.all(post_id, post_id, limit)
+			const results = stmt.all(post_id, post_id, limit);
 
-			return results.map((row: any) => row.post_id)
+			return results.map((row: any) => row.post_id);
 		} catch (fallback_error) {
-			console.error('Fallback query also failed:', fallback_error)
-			throw error
+			console.error('Fallback query also failed:', fallback_error);
+			throw error;
 		}
 	}
-}
+};
 
 export const get_post_embedding = async (
 	post_id: string,
 ): Promise<number[] | null> => {
-	const client = sqlite_client
+	const client = sqlite_client;
 	try {
 		const stmt = client.prepare(`
 			SELECT embedding FROM post_embeddings WHERE post_id = ?
-		`)
-		const result = stmt.get(post_id)
-		client.close()
+		`);
+		const result = stmt.get(post_id);
 
 		if (result) {
-			const embedding = result.embedding
+			const embedding = result.embedding;
 
 			// Handle different embedding formats
 			if (typeof embedding === 'string') {
 				// JSON format
 				try {
-					return JSON.parse(embedding)
+					return JSON.parse(embedding);
 				} catch {
 					// If not JSON, might be from migration - use vec_to_json
-					const json_client = sqlite_client
+					const json_client = sqlite_client;
 					const json_stmt = json_client.prepare(`
-						SELECT vec_to_json(embedding) as embedding_json 
+						SELECT vec_to_json(embedding) as embedding_json
 						FROM post_embeddings WHERE post_id = ?
-					`)
+					`);
 					const json_result = json_stmt.get(post_id) as
 						| { embedding_json: string }
-						| undefined
-					json_client.close()
+						| undefined;
+					json_client.close();
 
 					if (json_result && json_result.embedding_json) {
-						return JSON.parse(json_result.embedding_json)
+						return JSON.parse(json_result.embedding_json);
 					}
 				}
-			} else if (embedding instanceof Buffer) {
-				// Binary format from migration
-				return Array.from(new Float32Array(embedding))
+			} else if (ArrayBuffer.isView(embedding)) {
+				// node:sqlite returns BLOB values as Uint8Array instances.
+				return Array.from(
+					new Float32Array(
+						embedding.buffer,
+						embedding.byteOffset,
+						embedding.byteLength / Float32Array.BYTES_PER_ELEMENT,
+					),
+				);
 			}
 		}
 
-		return null
+		return null;
 	} catch (error) {
-		console.error('Error getting post embedding:', error)
-		client.close()
-		return null
+		console.error('Error getting post embedding:', error);
+		return null;
 	}
-}
+};

--- a/src/routes/api/ingest/pull-database.ts
+++ b/src/routes/api/ingest/pull-database.ts
@@ -2,27 +2,27 @@ import {
 	DATABASE_PATH,
 	INGEST_TOKEN,
 	PRODUCTION_URL,
-} from '$env/static/private'
-import Database from 'better-sqlite3'
-import fs from 'node:fs/promises'
-import path from 'node:path'
+} from '$env/static/private';
+import { backup, DatabaseSync } from 'node:sqlite';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 export const pull_database = async () => {
 	try {
 		const db_path =
 			DATABASE_PATH ||
-			path.join(process.cwd(), 'data', 'site-data.db')
-		const backups_dir = path.join(path.dirname(db_path), 'backups')
+			path.join(process.cwd(), 'data', 'site-data.db');
+		const backups_dir = path.join(path.dirname(db_path), 'backups');
 
 		// Ensure backups directory exists
-		await fs.mkdir(backups_dir, { recursive: true })
+		await fs.mkdir(backups_dir, { recursive: true });
 
 		if (!PRODUCTION_URL) {
-			throw new Error('PRODUCTION_URL environment variable not set')
+			throw new Error('PRODUCTION_URL environment variable not set');
 		}
 
 		// Download latest backup from production
-		console.log('Downloading latest backup from production...')
+		console.log('Downloading latest backup from production...');
 		const response = await fetch(
 			`${PRODUCTION_URL}/api/ingest/download`,
 			{
@@ -30,70 +30,72 @@ export const pull_database = async () => {
 					Authorization: `Bearer ${INGEST_TOKEN}`,
 				},
 			},
-		)
+		);
 
 		if (!response.ok) {
 			throw new Error(
 				`Failed to download backup: ${response.status} ${response.statusText}`,
-			)
+			);
 		}
 
 		// Save downloaded backup to temporary location
-		const now = new Date()
-		const date = now.toISOString().split('T')[0]
-		const hour = now.getHours().toString().padStart(2, '0')
-		const minute = now.getMinutes().toString().padStart(2, '0')
-		const downloaded_filename = `site-data-downloaded-${date}-${hour}${minute}.db`
+		const now = new Date();
+		const date = now.toISOString().split('T')[0];
+		const hour = now.getHours().toString().padStart(2, '0');
+		const minute = now.getMinutes().toString().padStart(2, '0');
+		const downloaded_filename = `site-data-downloaded-${date}-${hour}${minute}.db`;
 		const downloaded_path = path.join(
 			backups_dir,
 			downloaded_filename,
-		)
+		);
 
-		const arrayBuffer = await response.arrayBuffer()
-		await fs.writeFile(downloaded_path, new Uint8Array(arrayBuffer))
+		const arrayBuffer = await response.arrayBuffer();
+		await fs.writeFile(downloaded_path, new Uint8Array(arrayBuffer));
 
 		// Create backup of current local database before replacing using SQLite backup API
-		const current_backup_name = `site-data-local-backup-${date}-${hour}${minute}.db`
+		const current_backup_name = `site-data-local-backup-${date}-${hour}${minute}.db`;
 		const current_backup_path = path.join(
 			backups_dir,
 			current_backup_name,
-		)
+		);
 
 		try {
-			const current_db = new Database(db_path, { readonly: true })
+			const current_db = new DatabaseSync(db_path, {
+				readOnly: true,
+			});
 			try {
-				await current_db.backup(current_backup_path)
+				await backup(current_db, current_backup_path);
 			} finally {
-				current_db.close()
+				current_db.close();
 			}
 		} catch (error) {
 			console.warn(
 				'Could not backup current database (may not exist):',
 				error,
-			)
+			);
 		}
 
 		// Replace local database with downloaded backup using SQLite backup API
-		const downloaded_db = new Database(downloaded_path, {
-			readonly: true,
-		})
+		const downloaded_db = new DatabaseSync(downloaded_path, {
+			readOnly: true,
+		});
 
 		try {
-			await downloaded_db.backup(db_path)
+			await backup(downloaded_db, db_path);
 		} finally {
-			downloaded_db.close()
+			downloaded_db.close();
 		}
 
-		const imported_size = await fs.stat(db_path)
+		const imported_size = await fs.stat(db_path);
 
 		return {
 			message: 'Database pulled from production successfully',
 			downloaded_backup: downloaded_filename,
 			database_size: `${Math.round(imported_size.size / 1024 / 1024)}MB`,
 			local_backup_created: current_backup_name,
-		}
+		};
 	} catch (error) {
-		console.error('Error pulling database:', error)
-		throw error
+		console.error('Error pulling database:', error);
+		throw error;
 	}
-}
+};

--- a/src/routes/api/ingest/restore-database.ts
+++ b/src/routes/api/ingest/restore-database.ts
@@ -1,17 +1,17 @@
-import { DATABASE_PATH } from '$env/static/private'
-import Database from 'better-sqlite3'
-import fs from 'node:fs/promises'
-import path from 'node:path'
+import { DATABASE_PATH } from '$env/static/private';
+import { backup, DatabaseSync } from 'node:sqlite';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 export const restore_database = async (backup_filename?: string) => {
 	try {
 		const db_path =
 			DATABASE_PATH ||
-			path.join(process.cwd(), 'data', 'site-data.db')
-		const backups_dir = path.join(path.dirname(db_path), 'backups')
+			path.join(process.cwd(), 'data', 'site-data.db');
+		const backups_dir = path.join(path.dirname(db_path), 'backups');
 
 		// Find available backup files
-		const files = await fs.readdir(backups_dir)
+		const files = await fs.readdir(backups_dir);
 		const backup_files = files
 			.filter(
 				(file) =>
@@ -21,55 +21,59 @@ export const restore_database = async (backup_filename?: string) => {
 					!file.includes('corrupted'),
 			)
 			.sort()
-			.reverse() // newest first
+			.reverse(); // newest first
 
 		if (backup_files.length === 0) {
-			throw new Error('No backup files found in backups directory')
+			throw new Error('No backup files found in backups directory');
 		}
 
 		// Use specified backup or latest one
 		const backup_to_restore =
 			backup_filename && backup_files.includes(backup_filename)
 				? backup_filename
-				: backup_files[0]
+				: backup_files[0];
 
-		const backup_path = path.join(backups_dir, backup_to_restore)
+		const backup_path = path.join(backups_dir, backup_to_restore);
 
 		// Create backup of current database before restoring using SQLite backup API
-		const now = new Date()
-		const date = now.toISOString().split('T')[0]
-		const hour = now.getHours().toString().padStart(2, '0')
-		const minute = now.getMinutes().toString().padStart(2, '0')
-		const current_backup_name = `site-data-pre-restore-${date}-${hour}${minute}.db`
+		const now = new Date();
+		const date = now.toISOString().split('T')[0];
+		const hour = now.getHours().toString().padStart(2, '0');
+		const minute = now.getMinutes().toString().padStart(2, '0');
+		const current_backup_name = `site-data-pre-restore-${date}-${hour}${minute}.db`;
 		const current_backup_path = path.join(
 			backups_dir,
 			current_backup_name,
-		)
+		);
 
 		try {
-			const current_db = new Database(db_path, { readonly: true })
+			const current_db = new DatabaseSync(db_path, {
+				readOnly: true,
+			});
 			try {
-				await current_db.backup(current_backup_path)
+				await backup(current_db, current_backup_path);
 			} finally {
-				current_db.close()
+				current_db.close();
 			}
 		} catch (error) {
 			console.warn(
 				'Could not backup current database (may not exist):',
 				error,
-			)
+			);
 		}
 
 		// Restore from backup using SQLite backup API
-		const backup_db = new Database(backup_path, { readonly: true })
+		const backup_db = new DatabaseSync(backup_path, {
+			readOnly: true,
+		});
 
 		try {
-			await backup_db.backup(db_path)
+			await backup(backup_db, db_path);
 		} finally {
-			backup_db.close()
+			backup_db.close();
 		}
 
-		const restored_size = await fs.stat(db_path)
+		const restored_size = await fs.stat(db_path);
 
 		return {
 			message: 'Database restored successfully',
@@ -77,9 +81,9 @@ export const restore_database = async (backup_filename?: string) => {
 			database_size: `${Math.round(restored_size.size / 1024 / 1024)}MB`,
 			pre_restore_backup: current_backup_name,
 			available_backups: backup_files,
-		}
+		};
 	} catch (error) {
-		console.error('Error restoring database:', error)
-		throw error
+		console.error('Error restoring database:', error);
+		throw error;
 	}
-}
+};


### PR DESCRIPTION
## Summary
- replace better-sqlite3 with the built-in node:sqlite API
- preserve sqlite-vec, WAL, transactions, backup, pull, and restore behaviour
- require Node 24.15.0 and remove redundant native SQLite build packages
- add focused migration coverage

## Validation
- `pnpm exec svelte-check --tsconfig ./tsconfig.json`
- `pnpm test:server -- --run` (210 passed, 25 skipped)
- `pnpm build`
- focused node:sqlite migration tests (5 passed)
- changed-file LSP diagnostics clean

## Deployment
Coolify can continue to use Nixpacks. The Node engine now requires 24.15.0 or newer.