### PR TITLE
Fix node:sqlite E2E setup

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,5 +1,5 @@
-import Database from 'better-sqlite3'
 import { readFileSync, readdirSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
 import path from 'node:path'
 import * as sqliteVec from 'sqlite-vec'
 
@@ -8,11 +8,11 @@ export default async function global_setup() {
 
 	// Create database
 	const db_path = path.join(process.cwd(), 'data', 'site-data.db')
-	const db = new Database(db_path)
+	const db = new DatabaseSync(db_path, { allowExtension: true })
 
 	// Load sqlite-vec extension
 	try {
-		sqliteVec.load(db)
+		db.loadExtension(sqliteVec.getLoadablePath())
 		console.log('sqlite-vec extension loaded')
 	} catch (error) {
 		console.warn('Failed to load sqlite-vec extension:', error)


### PR DESCRIPTION
## Summary
- migrate the Playwright database seed setup from better-sqlite3 to node:sqlite
- keep sqlite-vec extension loading enabled for seeded embeddings

## Validation
- `pnpm run test:e2e` — 12 passed